### PR TITLE
Update opnsense-go to v0.2.0 & Use new error type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-opnsense
 go 1.20
 
 require (
-	github.com/browningluke/opnsense-go v0.1.0
+	github.com/browningluke/opnsense-go v0.2.0
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/browningluke/opnsense-go v0.1.0 h1:2wBoFYisneGepYbtQefMEP5cn1c0pPV050yeXlDlZ0o=
 github.com/browningluke/opnsense-go v0.1.0/go.mod h1:5hQQDOqd2lZQ1x/lO0oU/4Px+hZxBiG6tDRf1GbNPdg=
+github.com/browningluke/opnsense-go v0.2.0 h1:R+Cj0xYhbt1qMst4kVjQ4O7AHs4LhT6vWYdWEa9FebA=
+github.com/browningluke/opnsense-go v0.2.0/go.mod h1:5hQQDOqd2lZQ1x/lO0oU/4Px+hZxBiG6tDRf1GbNPdg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -93,7 +93,7 @@ func (p *OPNsenseProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	opnOptions := opnsense.Options{
+	opnOptions := api.Options{
 		Uri:           data.Uri.ValueString(),
 		APIKey:        data.APIKey.ValueString(),
 		APISecret:     data.APISecret.ValueString(),
@@ -103,7 +103,7 @@ func (p *OPNsenseProvider) Configure(ctx context.Context, req provider.Configure
 		MaxRetries:    data.MaxRetries.ValueInt64(),
 	}
 
-	client := opnsense.NewClient(opnOptions)
+	client := api.NewClient(opnOptions)
 	resp.DataSourceData = client
 	resp.ResourceData = client
 }

--- a/internal/service/interfaces_vlan_resource.go
+++ b/internal/service/interfaces_vlan_resource.go
@@ -3,7 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,7 +21,7 @@ func NewInterfacesVlanResource() resource.Resource {
 
 // InterfacesVlanResource defines the resource implementation.
 type InterfacesVlanResource struct {
-	client *opnsense.Client
+	client opnsense.Client
 }
 
 func (r *InterfacesVlanResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -37,7 +38,7 @@ func (r *InterfacesVlanResource) Configure(ctx context.Context, req resource.Con
 		return
 	}
 
-	client, ok := req.ProviderData.(*opnsense.Client)
+	apiClient, ok := req.ProviderData.(*api.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
@@ -46,7 +47,7 @@ func (r *InterfacesVlanResource) Configure(ctx context.Context, req resource.Con
 		return
 	}
 
-	r.client = client
+	r.client = opnsense.NewClient(apiClient)
 }
 
 func (r *InterfacesVlanResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -68,7 +69,7 @@ func (r *InterfacesVlanResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Add VLAN to OPNsense interfaces
-	id, err := r.client.Interfaces.AddVlan(ctx, vlan)
+	id, err := r.client.Interfaces().AddVlan(ctx, vlan)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create vlan, got error: %s", err))
@@ -96,7 +97,7 @@ func (r *InterfacesVlanResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	// Get VLAN from OPNsense core API
-	vlan, err := r.client.Interfaces.GetVlan(ctx, data.Id.ValueString())
+	vlan, err := r.client.Interfaces().GetVlan(ctx, data.Id.ValueString())
 	if err != nil {
 		if err.Error() == "unable to find resource. it may have been deleted upstream" {
 			tflog.Warn(ctx, fmt.Sprintf("vlan not present in remote, removing from state"))
@@ -149,7 +150,7 @@ func (r *InterfacesVlanResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Update VLAN in OPNsense core
-	err = r.client.Interfaces.UpdateVlan(ctx, data.Id.ValueString(), vlan)
+	err = r.client.Interfaces().UpdateVlan(ctx, data.Id.ValueString(), vlan)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create vlan, got error: %s", err))
@@ -170,7 +171,7 @@ func (r *InterfacesVlanResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	err := r.client.Interfaces.DeleteVlan(ctx, data.Id.ValueString())
+	err := r.client.Interfaces().DeleteVlan(ctx, data.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",

--- a/internal/service/interfaces_vlan_resource.go
+++ b/internal/service/interfaces_vlan_resource.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
 	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -99,7 +101,8 @@ func (r *InterfacesVlanResource) Read(ctx context.Context, req resource.ReadRequ
 	// Get VLAN from OPNsense core API
 	vlan, err := r.client.Interfaces().GetVlan(ctx, data.Id.ValueString())
 	if err != nil {
-		if err.Error() == "unable to find resource. it may have been deleted upstream" {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
 			tflog.Warn(ctx, fmt.Sprintf("vlan not present in remote, removing from state"))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/service/interfaces_vlan_schema.go
+++ b/internal/service/interfaces_vlan_schema.go
@@ -2,7 +2,8 @@ package service
 
 import (
 	"fmt"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/interfaces"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -74,17 +75,17 @@ func InterfacesVlanResourceSchema() schema.Schema {
 	}
 }
 
-func convertInterfacesVlanSchemaToStruct(d *InterfacesVlanResourceModel) (*opnsense.InterfacesVlan, error) {
-	return &opnsense.InterfacesVlan{
+func convertInterfacesVlanSchemaToStruct(d *InterfacesVlanResourceModel) (*interfaces.Vlan, error) {
+	return &interfaces.Vlan{
 		Description: d.Description.ValueString(),
 		Tag:         fmt.Sprintf("%d", d.Tag.ValueInt64()),
-		Priority:    opnsense.SelectedMap(fmt.Sprintf("%d", d.Priority.ValueInt64())),
-		Parent:      opnsense.SelectedMap(d.Parent.ValueString()),
+		Priority:    api.SelectedMap(fmt.Sprintf("%d", d.Priority.ValueInt64())),
+		Parent:      api.SelectedMap(d.Parent.ValueString()),
 		Device:      d.Device.ValueString(),
 	}, nil
 }
 
-func convertInterfacesVlanStructToSchema(d *opnsense.InterfacesVlan) (*InterfacesVlanResourceModel, error) {
+func convertInterfacesVlanStructToSchema(d *interfaces.Vlan) (*InterfacesVlanResourceModel, error) {
 	model := &InterfacesVlanResourceModel{
 		Description: types.StringNull(),
 		Tag:         types.Int64Null(),

--- a/internal/service/route_resource.go
+++ b/internal/service/route_resource.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
 	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -99,7 +101,8 @@ func (r *RouteResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	// Get route from OPNsense core API
 	route, err := r.client.Routes().GetRoute(ctx, data.Id.ValueString())
 	if err != nil {
-		if err.Error() == "unable to find resource. it may have been deleted upstream" {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
 			tflog.Warn(ctx, fmt.Sprintf("route not present in remote, removing from state"))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/service/route_resource.go
+++ b/internal/service/route_resource.go
@@ -3,7 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,7 +21,7 @@ func NewRouteResource() resource.Resource {
 
 // RouteResource defines the resource implementation.
 type RouteResource struct {
-	client *opnsense.Client
+	client opnsense.Client
 }
 
 func (r *RouteResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -37,7 +38,7 @@ func (r *RouteResource) Configure(ctx context.Context, req resource.ConfigureReq
 		return
 	}
 
-	client, ok := req.ProviderData.(*opnsense.Client)
+	apiClient, ok := req.ProviderData.(*api.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
@@ -46,7 +47,7 @@ func (r *RouteResource) Configure(ctx context.Context, req resource.ConfigureReq
 		return
 	}
 
-	r.client = client
+	r.client = opnsense.NewClient(apiClient)
 }
 
 func (r *RouteResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -68,7 +69,7 @@ func (r *RouteResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	// Add route to unbound
-	id, err := r.client.Routes.AddRoute(ctx, route)
+	id, err := r.client.Routes().AddRoute(ctx, route)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create route, got error: %s", err))
@@ -96,7 +97,7 @@ func (r *RouteResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	// Get route from OPNsense core API
-	route, err := r.client.Routes.GetRoute(ctx, data.Id.ValueString())
+	route, err := r.client.Routes().GetRoute(ctx, data.Id.ValueString())
 	if err != nil {
 		if err.Error() == "unable to find resource. it may have been deleted upstream" {
 			tflog.Warn(ctx, fmt.Sprintf("route not present in remote, removing from state"))
@@ -143,7 +144,7 @@ func (r *RouteResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// Update route in OPNsense core
-	err = r.client.Routes.UpdateRoute(ctx, data.Id.ValueString(), route)
+	err = r.client.Routes().UpdateRoute(ctx, data.Id.ValueString(), route)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create route, got error: %s", err))
@@ -164,7 +165,7 @@ func (r *RouteResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	err := r.client.Routes.DeleteRoute(ctx, data.Id.ValueString())
+	err := r.client.Routes().DeleteRoute(ctx, data.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",

--- a/internal/service/route_schema.go
+++ b/internal/service/route_schema.go
@@ -1,7 +1,8 @@
 package service
 
 import (
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/routes"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -53,7 +54,7 @@ func RouteResourceSchema() schema.Schema {
 	}
 }
 
-func convertRouteSchemaToStruct(d *RouteResourceModel) (*opnsense.Route, error) {
+func convertRouteSchemaToStruct(d *RouteResourceModel) (*routes.Route, error) {
 	// Convert 'Enabled' to 'Disabled'
 	var disabled string
 	if d.Enabled.ValueBool() {
@@ -62,15 +63,15 @@ func convertRouteSchemaToStruct(d *RouteResourceModel) (*opnsense.Route, error) 
 		disabled = "1"
 	}
 
-	return &opnsense.Route{
+	return &routes.Route{
 		Disabled:    disabled,
 		Description: d.Description.ValueString(),
-		Gateway:     opnsense.SelectedMap(d.Gateway.ValueString()),
+		Gateway:     api.SelectedMap(d.Gateway.ValueString()),
 		Network:     d.Network.ValueString(),
 	}, nil
 }
 
-func convertRouteStructToSchema(d *opnsense.Route) (*RouteResourceModel, error) {
+func convertRouteStructToSchema(d *routes.Route) (*RouteResourceModel, error) {
 	model := &RouteResourceModel{
 		Enabled:     types.BoolValue(true),
 		Description: types.StringNull(),

--- a/internal/service/unbound_domain_override_resource.go
+++ b/internal/service/unbound_domain_override_resource.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
 	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -99,7 +101,8 @@ func (r *UnboundDomainOverrideResource) Read(ctx context.Context, req resource.R
 	// Get domain override from OPNsense unbound API
 	override, err := r.client.Unbound().GetDomainOverride(ctx, data.Id.ValueString())
 	if err != nil {
-		if err.Error() == "unable to find resource. it may have been deleted upstream" {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
 			tflog.Warn(ctx, fmt.Sprintf("domain override not present in remote, removing from state"))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/service/unbound_domain_override_schema.go
+++ b/internal/service/unbound_domain_override_schema.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/unbound"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -53,7 +53,7 @@ func unboundDomainOverrideResourceSchema() schema.Schema {
 	}
 }
 
-func convertUnboundDomainOverrideSchemaToStruct(d *UnboundDomainOverrideResourceModel) (*opnsense.UnboundDomainOverride, error) {
+func convertUnboundDomainOverrideSchemaToStruct(d *UnboundDomainOverrideResourceModel) (*unbound.DomainOverride, error) {
 	// Parse 'Enabled'
 	var enabled string
 	if d.Enabled.ValueBool() {
@@ -62,7 +62,7 @@ func convertUnboundDomainOverrideSchemaToStruct(d *UnboundDomainOverrideResource
 		enabled = "0"
 	}
 
-	return &opnsense.UnboundDomainOverride{
+	return &unbound.DomainOverride{
 		Enabled:     enabled,
 		Domain:      d.Domain.ValueString(),
 		Server:      d.Server.ValueString(),
@@ -70,7 +70,7 @@ func convertUnboundDomainOverrideSchemaToStruct(d *UnboundDomainOverrideResource
 	}, nil
 }
 
-func convertUnboundDomainOverrideStructToSchema(d *opnsense.UnboundDomainOverride) (*UnboundDomainOverrideResourceModel, error) {
+func convertUnboundDomainOverrideStructToSchema(d *unbound.DomainOverride) (*UnboundDomainOverrideResourceModel, error) {
 	model := &UnboundDomainOverrideResourceModel{
 		Enabled:     types.BoolValue(false),
 		Domain:      types.StringValue(d.Domain),

--- a/internal/service/unbound_forward_resource.go
+++ b/internal/service/unbound_forward_resource.go
@@ -3,7 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,7 +21,7 @@ func NewUnboundForwardResource() resource.Resource {
 
 // UnboundForwardResource defines the resource implementation.
 type UnboundForwardResource struct {
-	client *opnsense.Client
+	client opnsense.Client
 }
 
 func (r *UnboundForwardResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -37,7 +38,7 @@ func (r *UnboundForwardResource) Configure(ctx context.Context, req resource.Con
 		return
 	}
 
-	client, ok := req.ProviderData.(*opnsense.Client)
+	apiClient, ok := req.ProviderData.(*api.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
@@ -46,7 +47,7 @@ func (r *UnboundForwardResource) Configure(ctx context.Context, req resource.Con
 		return
 	}
 
-	r.client = client
+	r.client = opnsense.NewClient(apiClient)
 }
 
 func (r *UnboundForwardResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -68,7 +69,7 @@ func (r *UnboundForwardResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Add forward to unbound
-	id, err := r.client.Unbound.AddForward(ctx, forward)
+	id, err := r.client.Unbound().AddForward(ctx, forward)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create forward, got error: %s", err))
@@ -96,7 +97,7 @@ func (r *UnboundForwardResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	// Get forward from OPNsense unbound API
-	forward, err := r.client.Unbound.GetForward(ctx, data.Id.ValueString())
+	forward, err := r.client.Unbound().GetForward(ctx, data.Id.ValueString())
 	if err != nil {
 		if err.Error() == "unable to find resource. it may have been deleted upstream" {
 			tflog.Warn(ctx, fmt.Sprintf("forward not present in remote, removing from state"))
@@ -143,7 +144,7 @@ func (r *UnboundForwardResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Update forward in unbound
-	err = r.client.Unbound.UpdateForward(ctx, data.Id.ValueString(), forward)
+	err = r.client.Unbound().UpdateForward(ctx, data.Id.ValueString(), forward)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create forward, got error: %s", err))
@@ -164,7 +165,7 @@ func (r *UnboundForwardResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	err := r.client.Unbound.DeleteForward(ctx, data.Id.ValueString())
+	err := r.client.Unbound().DeleteForward(ctx, data.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",

--- a/internal/service/unbound_forward_resource.go
+++ b/internal/service/unbound_forward_resource.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
 	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -99,7 +101,8 @@ func (r *UnboundForwardResource) Read(ctx context.Context, req resource.ReadRequ
 	// Get forward from OPNsense unbound API
 	forward, err := r.client.Unbound().GetForward(ctx, data.Id.ValueString())
 	if err != nil {
-		if err.Error() == "unable to find resource. it may have been deleted upstream" {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
 			tflog.Warn(ctx, fmt.Sprintf("forward not present in remote, removing from state"))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/service/unbound_forward_schema.go
+++ b/internal/service/unbound_forward_schema.go
@@ -2,7 +2,8 @@ package service
 
 import (
 	"fmt"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/unbound"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -78,7 +79,7 @@ func unboundForwardResourceSchema() schema.Schema {
 	}
 }
 
-func convertUnboundForwardSchemaToStruct(d *UnboundForwardResourceModel) (*opnsense.UnboundForward, error) {
+func convertUnboundForwardSchemaToStruct(d *UnboundForwardResourceModel) (*unbound.Forward, error) {
 	// Parse 'Enabled'
 	var enabled string
 	if d.Enabled.ValueBool() {
@@ -87,17 +88,17 @@ func convertUnboundForwardSchemaToStruct(d *UnboundForwardResourceModel) (*opnse
 		enabled = "0"
 	}
 
-	return &opnsense.UnboundForward{
+	return &unbound.Forward{
 		Enabled:  enabled,
 		Domain:   d.Domain.ValueString(),
-		Type:     opnsense.SelectedMap(d.Type.ValueString()),
+		Type:     api.SelectedMap(d.Type.ValueString()),
 		Server:   d.ServerIP.ValueString(),
 		Port:     fmt.Sprintf("%d", d.ServerPort.ValueInt64()),
 		VerifyCN: d.VerifyCN.ValueString(),
 	}, nil
 }
 
-func convertUnboundForwardStructToSchema(d *opnsense.UnboundForward) (*UnboundForwardResourceModel, error) {
+func convertUnboundForwardStructToSchema(d *unbound.Forward) (*UnboundForwardResourceModel, error) {
 	// Parse 'ServerPort'
 	serverPort, err := strconv.ParseInt(d.Port, 10, 64)
 	if err != nil {

--- a/internal/service/unbound_host_alias_resource.go
+++ b/internal/service/unbound_host_alias_resource.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
 	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -99,7 +101,8 @@ func (r *UnboundHostAliasResource) Read(ctx context.Context, req resource.ReadRe
 	// Get host alias from OPNsense unbound API
 	alias, err := r.client.Unbound().GetHostAlias(ctx, data.Id.ValueString())
 	if err != nil {
-		if err.Error() == "unable to find resource. it may have been deleted upstream" {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
 			tflog.Warn(ctx, fmt.Sprintf("host alias not present in remote, removing from state"))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/service/unbound_host_alias_schema.go
+++ b/internal/service/unbound_host_alias_schema.go
@@ -1,7 +1,8 @@
 package service
 
 import (
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/unbound"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -61,7 +62,7 @@ func unboundHostAliasResourceSchema() schema.Schema {
 	}
 }
 
-func convertUnboundHostAliasSchemaToStruct(d *UnboundHostAliasResourceModel) (*opnsense.UnboundHostAlias, error) {
+func convertUnboundHostAliasSchemaToStruct(d *UnboundHostAliasResourceModel) (*unbound.HostAlias, error) {
 	// Parse 'Enabled'
 	var enabled string
 	if d.Enabled.ValueBool() {
@@ -70,16 +71,16 @@ func convertUnboundHostAliasSchemaToStruct(d *UnboundHostAliasResourceModel) (*o
 		enabled = "0"
 	}
 
-	return &opnsense.UnboundHostAlias{
+	return &unbound.HostAlias{
 		Enabled:     enabled,
-		Host:        opnsense.SelectedMap(d.Override.ValueString()),
+		Host:        api.SelectedMap(d.Override.ValueString()),
 		Hostname:    d.Hostname.ValueString(),
 		Domain:      d.Domain.ValueString(),
 		Description: d.Description.ValueString(),
 	}, nil
 }
 
-func convertUnboundHostAliasStructToSchema(d *opnsense.UnboundHostAlias) (*UnboundHostAliasResourceModel, error) {
+func convertUnboundHostAliasStructToSchema(d *unbound.HostAlias) (*UnboundHostAliasResourceModel, error) {
 	model := &UnboundHostAliasResourceModel{
 		Enabled:     types.BoolValue(false),
 		Hostname:    types.StringValue(d.Hostname),

--- a/internal/service/unbound_host_override_resource.go
+++ b/internal/service/unbound_host_override_resource.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
 	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -99,7 +101,8 @@ func (r *UnboundHostOverrideResource) Read(ctx context.Context, req resource.Rea
 	// Get host override from OPNsense unbound API
 	override, err := r.client.Unbound().GetHostOverride(ctx, data.Id.ValueString())
 	if err != nil {
-		if err.Error() == "unable to find resource. it may have been deleted upstream" {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
 			tflog.Warn(ctx, fmt.Sprintf("host override not present in remote, removing from state"))
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/service/unbound_host_override_resource.go
+++ b/internal/service/unbound_host_override_resource.go
@@ -3,7 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,7 +21,7 @@ func NewUnboundHostOverrideResource() resource.Resource {
 
 // UnboundHostOverrideResource defines the resource implementation.
 type UnboundHostOverrideResource struct {
-	client *opnsense.Client
+	client opnsense.Client
 }
 
 func (r *UnboundHostOverrideResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -37,7 +38,7 @@ func (r *UnboundHostOverrideResource) Configure(ctx context.Context, req resourc
 		return
 	}
 
-	client, ok := req.ProviderData.(*opnsense.Client)
+	apiClient, ok := req.ProviderData.(*api.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
@@ -46,7 +47,7 @@ func (r *UnboundHostOverrideResource) Configure(ctx context.Context, req resourc
 		return
 	}
 
-	r.client = client
+	r.client = opnsense.NewClient(apiClient)
 }
 
 func (r *UnboundHostOverrideResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -68,7 +69,7 @@ func (r *UnboundHostOverrideResource) Create(ctx context.Context, req resource.C
 	}
 
 	// Add host override to unbound
-	id, err := r.client.Unbound.AddHostOverride(ctx, hostOverride)
+	id, err := r.client.Unbound().AddHostOverride(ctx, hostOverride)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create host override, got error: %s", err))
@@ -96,7 +97,7 @@ func (r *UnboundHostOverrideResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	// Get host override from OPNsense unbound API
-	override, err := r.client.Unbound.GetHostOverride(ctx, data.Id.ValueString())
+	override, err := r.client.Unbound().GetHostOverride(ctx, data.Id.ValueString())
 	if err != nil {
 		if err.Error() == "unable to find resource. it may have been deleted upstream" {
 			tflog.Warn(ctx, fmt.Sprintf("host override not present in remote, removing from state"))
@@ -143,7 +144,7 @@ func (r *UnboundHostOverrideResource) Update(ctx context.Context, req resource.U
 	}
 
 	// Update host override in unbound
-	err = r.client.Unbound.UpdateHostOverride(ctx, data.Id.ValueString(), hostOverride)
+	err = r.client.Unbound().UpdateHostOverride(ctx, data.Id.ValueString(), hostOverride)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create host override, got error: %s", err))
@@ -164,7 +165,7 @@ func (r *UnboundHostOverrideResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	err := r.client.Unbound.DeleteHostOverride(ctx, data.Id.ValueString())
+	err := r.client.Unbound().DeleteHostOverride(ctx, data.Id.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error",

--- a/internal/service/unbound_host_override_schema.go
+++ b/internal/service/unbound_host_override_schema.go
@@ -2,7 +2,8 @@ package service
 
 import (
 	"fmt"
-	"github.com/browningluke/opnsense-go"
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/unbound"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -103,7 +104,7 @@ func unboundHostOverrideResourceSchema() schema.Schema {
 	}
 }
 
-func convertUnboundHostOverrideSchemaToStruct(d *UnboundHostOverrideResourceModel) (*opnsense.UnboundHostOverride, error) {
+func convertUnboundHostOverrideSchemaToStruct(d *UnboundHostOverrideResourceModel) (*unbound.HostOverride, error) {
 	// Parse 'Enabled'
 	var enabled string
 	if d.Enabled.ValueBool() {
@@ -118,11 +119,11 @@ func convertUnboundHostOverrideSchemaToStruct(d *UnboundHostOverrideResourceMode
 		mxPriority = ""
 	}
 
-	return &opnsense.UnboundHostOverride{
+	return &unbound.HostOverride{
 		Enabled:     enabled,
 		Hostname:    d.Hostname.ValueString(),
 		Domain:      d.Domain.ValueString(),
-		Type:        opnsense.SelectedMap(d.Type.ValueString()),
+		Type:        api.SelectedMap(d.Type.ValueString()),
 		Server:      d.Server.ValueString(),
 		MXDomain:    d.MXDomain.ValueString(),
 		MXPriority:  mxPriority,
@@ -130,7 +131,7 @@ func convertUnboundHostOverrideSchemaToStruct(d *UnboundHostOverrideResourceMode
 	}, nil
 }
 
-func convertUnboundHostOverrideStructToSchema(d *opnsense.UnboundHostOverride) (*UnboundHostOverrideResourceModel, error) {
+func convertUnboundHostOverrideStructToSchema(d *unbound.HostOverride) (*UnboundHostOverrideResourceModel, error) {
 	model := &UnboundHostOverrideResourceModel{
 		Enabled:     types.BoolValue(false),
 		Hostname:    types.StringValue(d.Hostname),


### PR DESCRIPTION
- Handle API module restructure
- Catch NotFoundError specifically when reading
- Bump opnsense-go to v0.2.0
