### PR TITLE
Add validators to firewall filter & nat resources

### DIFF
--- a/docs/data-sources/firewall_filter.md
+++ b/docs/data-sources/firewall_filter.md
@@ -21,7 +21,7 @@ Firewall filter rules can be used to restrict or allow traffic from and/or to sp
 ### Read-Only
 
 - `action` (String) Choose what to do with packets that match the criteria specified below. Hint: the difference between block and reject is that with reject, a packet (TCP RST or ICMP port unreachable for UDP) is returned to the sender, whereas with block the packet is dropped silently. In either case, the original packet is discarded. Available values: `pass`, `block`, `reject`.
-- `description` (String) Optional description here for your reference (not parsed).
+- `description` (String) Optional description here for your reference (not parsed). Must be between 1 and 255 characters. Must be a character in set `[a-zA-Z0-9 .]`.
 - `destination` (Attributes) (see [below for nested schema](#nestedatt--destination))
 - `direction` (String) Direction of the traffic. The default policy is to filter inbound traffic, which sets the policy to the interface originally receiving the traffic. Available values: `in`, `out`.
 - `enabled` (Boolean) Enable this firewall filter rule.

--- a/docs/resources/firewall_nat.md
+++ b/docs/resources/firewall_nat.md
@@ -86,7 +86,7 @@ resource "opnsense_firewall_nat" "example_three" {
 
 ### Optional
 
-- `description` (String) Optional description here for your reference (not parsed).
+- `description` (String) Optional description here for your reference (not parsed). Must be between 1 and 255 characters. Must be a character in set `[a-zA-Z0-9 .]`.
 - `destination` (Attributes) (see [below for nested schema](#nestedatt--destination))
 - `disable_nat` (Boolean) Enabling this option will disable NAT for traffic matching this rule and stop processing Outbound NAT rules. Defaults to `false`.
 - `enabled` (Boolean) Enable this firewall NAT rule. Defaults to `true`.

--- a/internal/service/firewall_filter_schema.go
+++ b/internal/service/firewall_filter_schema.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"regexp"
 	"terraform-provider-opnsense/internal/tools"
 )
 
@@ -297,8 +298,15 @@ func FirewallFilterDataSourceSchema() dschema.Schema {
 				Computed:            true,
 			},
 			"description": dschema.StringAttribute{
-				MarkdownDescription: "Optional description here for your reference (not parsed).",
+				MarkdownDescription: "Optional description here for your reference (not parsed). Must be between 1 and 255 characters. Must be a character in set `[a-zA-Z0-9 .]`.",
 				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-zA-Z0-9 .]*$`),
+						"must only contain only alphanumeric characters, spaces or `.`",
+					),
+					stringvalidator.LengthBetween(1, 255),
+				},
 			},
 		},
 	}

--- a/internal/service/firewall_nat_schema.go
+++ b/internal/service/firewall_nat_schema.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"regexp"
 	"terraform-provider-opnsense/internal/tools"
 )
 
@@ -182,8 +183,15 @@ func FirewallNATResourceSchema() schema.Schema {
 				Default:             booldefault.StaticBool(false),
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: "Optional description here for your reference (not parsed).",
+				MarkdownDescription: "Optional description here for your reference (not parsed). Must be between 1 and 255 characters. Must be a character in set `[a-zA-Z0-9 .]`.",
 				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-zA-Z0-9 .]*$`),
+						"must only contain only alphanumeric characters, spaces or `.`",
+					),
+					stringvalidator.LengthBetween(1, 255),
+				},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
While the firewall options built into OPNsense handle special characters, the os-firewall plugin only accepts alphanumeric characters, spaces, and periods.

This was the root issue that was happening in https://github.com/browningluke/terraform-provider-opnsense/issues/28#issue-1883771923 (section 1).