### PR TITLE
Fix Wireguard docs errors

### DIFF
--- a/docs/resources/wireguard_client.md
+++ b/docs/resources/wireguard_client.md
@@ -12,16 +12,6 @@ Client resources can be used to setup Wireguard clients.
 ## Example Usage
 
 ```terraform
-// Generate random 256-bit base64 public key
-resource "random_id" "pubkey" {
-  byte_length = 32
-}
-
-// Generate random 256-bit base64 private key
-resource "random_id" "privkey" {
-  byte_length = 32
-}
-
 // Configure a peer
 resource "opnsense_wireguard_client" "example0" {
   enabled = false
@@ -37,28 +27,6 @@ resource "opnsense_wireguard_client" "example0" {
 
   server_address = "10.10.10.10"
   server_port    = "1234"
-}
-
-// Configure the server
-resource "opnsense_wireguard_server" "example0" {
-  name = "example0"
-
-  private_key = random_id.privkey.b64_std
-  public_key  = random_id.pubkey.b64_std
-
-  dns = [
-    "1.1.1.1",
-    "8.8.8.8"
-  ]
-
-  tunnel_address = [
-    "192.168.1.100/32",
-    "10.10.0.0/24"
-  ]
-
-  peers = [
-    opnsense_wireguard_client.example0.id
-  ]
 }
 ```
 

--- a/docs/resources/wireguard_server.md
+++ b/docs/resources/wireguard_server.md
@@ -12,6 +12,11 @@ Server resources can be used to setup Wireguard servers.
 ## Example Usage
 
 ```terraform
+// Generate an wireguard_asymmetric_key
+// This uses the OJFord/wireguard provider
+resource "wireguard_asymmetric_key" "example0" {
+}
+
 // Configure a peer
 resource "opnsense_wireguard_client" "example0" {
   enabled = false
@@ -27,6 +32,28 @@ resource "opnsense_wireguard_client" "example0" {
 
   server_address = "10.10.10.10"
   server_port    = "1234"
+}
+
+// Configure the server
+resource "opnsense_wireguard_server" "example0" {
+  name = "example0"
+
+  private_key = wireguard_asymmetric_key.example0.private_key
+  public_key  = wireguard_asymmetric_key.example0.public_key
+
+  dns = [
+    "1.1.1.1",
+    "8.8.8.8"
+  ]
+
+  tunnel_address = [
+    "192.168.1.100/32",
+    "10.10.0.0/24"
+  ]
+
+  peers = [
+    opnsense_wireguard_client.example0.id
+  ]
 }
 ```
 

--- a/examples/resources/opnsense_wireguard_client/resource.tf
+++ b/examples/resources/opnsense_wireguard_client/resource.tf
@@ -1,13 +1,3 @@
-// Generate random 256-bit base64 public key
-resource "random_id" "pubkey" {
-  byte_length = 32
-}
-
-// Generate random 256-bit base64 private key
-resource "random_id" "privkey" {
-  byte_length = 32
-}
-
 // Configure a peer
 resource "opnsense_wireguard_client" "example0" {
   enabled = false
@@ -23,26 +13,4 @@ resource "opnsense_wireguard_client" "example0" {
 
   server_address = "10.10.10.10"
   server_port    = "1234"
-}
-
-// Configure the server
-resource "opnsense_wireguard_server" "example0" {
-  name = "example0"
-
-  private_key = random_id.privkey.b64_std
-  public_key  = random_id.pubkey.b64_std
-
-  dns = [
-    "1.1.1.1",
-    "8.8.8.8"
-  ]
-
-  tunnel_address = [
-    "192.168.1.100/32",
-    "10.10.0.0/24"
-  ]
-
-  peers = [
-    opnsense_wireguard_client.example0.id
-  ]
 }

--- a/examples/resources/opnsense_wireguard_server/resource.tf
+++ b/examples/resources/opnsense_wireguard_server/resource.tf
@@ -1,3 +1,8 @@
+// Generate an wireguard_asymmetric_key
+// This uses the OJFord/wireguard provider
+resource "wireguard_asymmetric_key" "example0" {
+}
+
 // Configure a peer
 resource "opnsense_wireguard_client" "example0" {
   enabled = false
@@ -13,4 +18,26 @@ resource "opnsense_wireguard_client" "example0" {
 
   server_address = "10.10.10.10"
   server_port    = "1234"
+}
+
+// Configure the server
+resource "opnsense_wireguard_server" "example0" {
+  name = "example0"
+
+  private_key = wireguard_asymmetric_key.example0.private_key
+  public_key  = wireguard_asymmetric_key.example0.public_key
+
+  dns = [
+    "1.1.1.1",
+    "8.8.8.8"
+  ]
+
+  tunnel_address = [
+    "192.168.1.100/32",
+    "10.10.0.0/24"
+  ]
+
+  peers = [
+    opnsense_wireguard_client.example0.id
+  ]
 }


### PR DESCRIPTION
The current docs contain 2 errors:
1. The examples for the client and server were switched
2. The example code for generating a keypair was naive and used 2 random base64 strings

This PR switches the examples around, and uses [a proper method](https://registry.terraform.io/providers/OJFord/wireguard/latest/docs/resources/asymmetric_key) to generate the keypair.