### PR TITLE
Mark Wireguard private key and PSK as sensitive attributes

### DIFF
--- a/docs/data-sources/wireguard_client.md
+++ b/docs/data-sources/wireguard_client.md
@@ -21,7 +21,7 @@ Client resources can be used to setup Wireguard clients.
 - `enabled` (Boolean) Whether this client config is enabled.
 - `keep_alive` (Number) The persistent keepalive interval in seconds.
 - `name` (String) Name of the client config.
-- `psk` (String) Shared secret (PSK) for this peer.
+- `psk` (String, Sensitive) Shared secret (PSK) for this peer.
 - `public_key` (String) Public key of this client config.
 - `server_address` (String) The public IP address the endpoint listens to.
 - `server_port` (Number) The port the endpoint listens to.

--- a/docs/data-sources/wireguard_server.md
+++ b/docs/data-sources/wireguard_server.md
@@ -27,7 +27,7 @@ Server resources can be used to setup Wireguard servers.
 - `name` (String) Name of the server.
 - `peers` (Set of String) List of peer IDs for this server.
 - `port` (Number) The fixed port for this instance to listen on. The standard port range starts at 51820.
-- `private_key` (String) Private key of this server.
+- `private_key` (String, Sensitive) Private key of this server.
 - `public_key` (String) Public key of this server.
 - `tunnel_address` (Set of String) List of addresses to configure on the tunnel adapter.
 

--- a/docs/resources/wireguard_client.md
+++ b/docs/resources/wireguard_client.md
@@ -43,7 +43,7 @@ resource "opnsense_wireguard_client" "example0" {
 
 - `enabled` (Boolean) Enable this client config. Defaults to `true`.
 - `keep_alive` (Number) The persistent keepalive interval in seconds. Defaults to `-1`.
-- `psk` (String) Shared secret (PSK) for this peer. You can generate a key using `wg genpsk` on a client with WireGuard installed. Must be a 256-bit base64 string. Defaults to `""`.
+- `psk` (String, Sensitive) Shared secret (PSK) for this peer. You can generate a key using `wg genpsk` on a client with WireGuard installed. Must be a 256-bit base64 string. Defaults to `""`.
 - `server_address` (String) The public IP address the endpoint listens to. Defaults to `""`.
 - `server_port` (Number) The port the endpoint listens to. Defaults to `-1`.
 

--- a/docs/resources/wireguard_server.md
+++ b/docs/resources/wireguard_server.md
@@ -63,7 +63,7 @@ resource "opnsense_wireguard_server" "example0" {
 ### Required
 
 - `name` (String) Name of the server.
-- `private_key` (String) Private key of this server. Must be a 256-bit base64 string.
+- `private_key` (String, Sensitive) Private key of this server. Must be a 256-bit base64 string.
 - `public_key` (String) Public key of this server. Must be a 256-bit base64 string.
 
 ### Optional

--- a/internal/service/wireguard_client_schema.go
+++ b/internal/service/wireguard_client_schema.go
@@ -53,6 +53,7 @@ func wireguardClientResourceSchema() schema.Schema {
 				MarkdownDescription: "Shared secret (PSK) for this peer. You can generate a key using `wg genpsk` on a client with WireGuard installed. Must be a 256-bit base64 string. Defaults to `\"\"`.",
 				Optional:            true,
 				Computed:            true,
+				Sensitive:           true,
 				Default:             stringdefault.StaticString(""),
 			},
 			"server_address": schema.StringAttribute{
@@ -116,6 +117,7 @@ func WireguardClientDataSourceSchema() dschema.Schema {
 			"psk": schema.StringAttribute{
 				MarkdownDescription: "Shared secret (PSK) for this peer.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"server_address": schema.StringAttribute{
 				MarkdownDescription: "The public IP address the endpoint listens to.",

--- a/internal/service/wireguard_server_schema.go
+++ b/internal/service/wireguard_server_schema.go
@@ -58,6 +58,7 @@ func wireguardServerResourceSchema() schema.Schema {
 			"private_key": schema.StringAttribute{
 				MarkdownDescription: "Private key of this server. Must be a 256-bit base64 string.",
 				Required:            true,
+				Sensitive:           true,
 			},
 			"port": schema.Int64Attribute{
 				MarkdownDescription: "The fixed port for this instance to listen on. The standard port range starts at 51820. Defaults to `-1`.",
@@ -152,6 +153,7 @@ func WireguardServerDataSourceSchema() dschema.Schema {
 			"private_key": schema.StringAttribute{
 				MarkdownDescription: "Private key of this server.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"port": schema.Int64Attribute{
 				MarkdownDescription: "The fixed port for this instance to listen on. The standard port range starts at 51820.",


### PR DESCRIPTION
These values contain sensitive data, and should thus be marked as sensitive. This PR fixes this issue.