### PR TITLE
Change os-firewall port type from int to string

### DIFF
--- a/docs/data-sources/firewall_filter.md
+++ b/docs/data-sources/firewall_filter.md
@@ -41,7 +41,7 @@ Read-Only:
 
 - `invert` (Boolean) Use this option to invert the sense of the match.
 - `net` (String) Specify the IP address, CIDR or alias for the destination of the packet for this mapping.
-- `port` (Number) Specify the port for the destination of the packet for this mapping.
+- `port` (String) Specify the port for the destination of the packet for this mapping.
 
 
 <a id="nestedatt--source"></a>
@@ -51,5 +51,5 @@ Read-Only:
 
 - `invert` (Boolean) Use this option to invert the sense of the match.
 - `net` (String) Specify the IP address, CIDR or alias for the source of the packet for this mapping.
-- `port` (Number) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `-1`).
+- `port` (String) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `""`).
 

--- a/docs/data-sources/firewall_nat.md
+++ b/docs/data-sources/firewall_nat.md
@@ -39,7 +39,7 @@ Read-Only:
 
 - `invert` (Boolean) Use this option to invert the sense of the match.
 - `net` (String) Specify the IP address, CIDR or alias for the destination of the packet for this mapping.
-- `port` (Number) Specify the port for the destination of the packet for this mapping.
+- `port` (String) Specify the port for the destination of the packet for this mapping.
 
 
 <a id="nestedatt--source"></a>
@@ -49,7 +49,7 @@ Read-Only:
 
 - `invert` (Boolean) Use this option to invert the sense of the match.
 - `net` (String) Specify the IP address, CIDR or alias for the source of the packet for this mapping.
-- `port` (Number) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `-1`).
+- `port` (String) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `""`).
 
 
 <a id="nestedatt--target"></a>
@@ -58,5 +58,5 @@ Read-Only:
 Read-Only:
 
 - `ip` (String) Specify the IP address or alias for the packets to be mapped to.
-- `port` (Number) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash.
+- `port` (String) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash.
 

--- a/docs/resources/firewall_filter.md
+++ b/docs/resources/firewall_filter.md
@@ -37,7 +37,7 @@ resource "opnsense_firewall_filter" "example_one" {
 
   destination = {
     net    = "examplealias"
-    port   = 443
+    port   = "https"
   }
 
   log = false
@@ -59,7 +59,7 @@ resource "opnsense_firewall_filter" "example_two" {
 
   destination = {
     net  = "10.8.0.1"
-    port = 443
+    port = "443"
   }
 
   description = "example rule"
@@ -80,7 +80,7 @@ resource "opnsense_firewall_filter" "example_three" {
 
   destination = {
     net  = "wanip" # This is equiv. to WAN Address
-    port = 443
+    port = "80-443"
   }
 
   description = "example rule"
@@ -121,7 +121,7 @@ Optional:
 
 - `invert` (Boolean) Use this option to invert the sense of the match. Defaults to `false`.
 - `net` (String) Specify the IP address, CIDR or alias for the destination of the packet for this mapping. For `<INT> net`, enter `<int>` (e.g. `lan`). For `<INT> address`, enter `<int>ip` (e.g. `lanip`). Defaults to `any`.
-- `port` (Number) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash. Defaults to `-1`.
+- `port` (String) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash. Defaults to `""`.
 
 
 <a id="nestedatt--source"></a>
@@ -131,5 +131,5 @@ Optional:
 
 - `invert` (Boolean) Use this option to invert the sense of the match. Defaults to `false`.
 - `net` (String) Specify the IP address, CIDR or alias for the source of the packet for this mapping. For `<INT> net`, enter `<int>` (e.g. `lan`). For `<INT> address`, enter `<int>ip` (e.g. `lanip`). Defaults to `any`.
-- `port` (Number) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `-1`). Defaults to `-1`.
+- `port` (String) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `""`). Defaults to `""`.
 

--- a/docs/resources/firewall_nat.md
+++ b/docs/resources/firewall_nat.md
@@ -40,12 +40,12 @@ resource "opnsense_firewall_nat" "example_two" {
 
   destination = {
     net  = "10.8.0.1"
-    port = 443
+    port = "443"
   }
 
   target = {
     ip = "wanip"
-    port = 80
+    port = "http"
   }
 
   log         = true
@@ -63,12 +63,12 @@ resource "opnsense_firewall_nat" "example_three" {
 
   destination = {
     net  = "examplealias"
-    port = 443
+    port = "80-443"
   }
 
   target = {
     ip = "wanip"
-    port = 443
+    port = "443"
   }
 
   description = "Example"
@@ -108,7 +108,7 @@ Required:
 
 Optional:
 
-- `port` (Number) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash. Defaults to `-1`.
+- `port` (String) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash. Defaults to `""`.
 
 
 <a id="nestedatt--destination"></a>
@@ -118,7 +118,7 @@ Optional:
 
 - `invert` (Boolean) Use this option to invert the sense of the match. Defaults to `false`.
 - `net` (String) Specify the IP address, CIDR or alias for the destination of the packet for this mapping. For `<INT> net`, enter `<int>` (e.g. `lan`). For `<INT> address`, enter `<int>ip` (e.g. `lanip`). Defaults to `any`.
-- `port` (Number) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash. Defaults to `-1`.
+- `port` (String) Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash. Defaults to `""`.
 
 
 <a id="nestedatt--source"></a>
@@ -128,5 +128,5 @@ Optional:
 
 - `invert` (Boolean) Use this option to invert the sense of the match. Defaults to `false`.
 - `net` (String) Specify the IP address, CIDR or alias for the source of the packet for this mapping. For `<INT> net`, enter `<int>` (e.g. `lan`). For `<INT> address`, enter `<int>ip` (e.g. `lanip`). Defaults to `any`.
-- `port` (Number) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `-1`). Defaults to `-1`.
+- `port` (String) Specify the source port for this rule. This is usually random and almost never equal to the destination port range (and should usually be `""`). Defaults to `""`.
 

--- a/examples/resources/opnsense_firewall_filter/resource.tf
+++ b/examples/resources/opnsense_firewall_filter/resource.tf
@@ -21,7 +21,7 @@ resource "opnsense_firewall_filter" "example_one" {
 
   destination = {
     net    = "examplealias"
-    port   = 443
+    port   = "https"
   }
 
   log = false
@@ -43,7 +43,7 @@ resource "opnsense_firewall_filter" "example_two" {
 
   destination = {
     net  = "10.8.0.1"
-    port = 443
+    port = "443"
   }
 
   description = "example rule"
@@ -64,7 +64,7 @@ resource "opnsense_firewall_filter" "example_three" {
 
   destination = {
     net  = "wanip" # This is equiv. to WAN Address
-    port = 443
+    port = "80-443"
   }
 
   description = "example rule"

--- a/examples/resources/opnsense_firewall_nat/resource.tf
+++ b/examples/resources/opnsense_firewall_nat/resource.tf
@@ -24,12 +24,12 @@ resource "opnsense_firewall_nat" "example_two" {
 
   destination = {
     net  = "10.8.0.1"
-    port = 443
+    port = "443"
   }
 
   target = {
     ip = "wanip"
-    port = 80
+    port = "http"
   }
 
   log         = true
@@ -47,12 +47,12 @@ resource "opnsense_firewall_nat" "example_three" {
 
   destination = {
     net  = "examplealias"
-    port = 443
+    port = "80-443"
   }
 
   target = {
     ip = "wanip"
-    port = 443
+    port = "443"
   }
 
   description = "Example"


### PR DESCRIPTION
As raised in https://github.com/browningluke/terraform-provider-opnsense/issues/34, the current implementation of the `opnsense_firewall_nat` & `opnsense_firewall_nat` resources uses an int64 type for the `port` attr. It can only accept a single value for the ports, while the docs say it can accept a number, range, or well known name.

This PR fixes this issue. Note, it potentially introduces state changes (e.g. `-1` -> `""`) to existing deployments. I've tested this and it _seems_ like TF is happy to migrate the state on its own. This may, however, cause some existing resources to break, and have to be re-imported.