### PR TITLE
Allow provider to be configured from env vars

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -12,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"os"
 	"strconv"
 	"terraform-provider-opnsense/internal/service"
@@ -269,8 +267,6 @@ func (p *OPNsenseProvider) Configure(ctx context.Context, req provider.Configure
 		MaxRetries:    retries,
 	}
 	client := api.NewClient(opnOptions)
-
-	tflog.Warn(ctx, fmt.Sprintf("Created client with options: %+v\n", opnOptions))
 
 	resp.DataSourceData = client
 	resp.ResourceData = client

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -305,7 +305,6 @@ func (p *OPNsenseProvider) DataSources(ctx context.Context) []func() datasource.
 		// Interfaces
 		service.NewInterfacesVlanDataSource,
 		service.NewInterfaceDataSource,
-		service.NewInterfaceAllDataSource,
 		// Routes
 		service.NewRouteDataSource,
 		// Unbound


### PR DESCRIPTION
The docs say that the providers can be configured using `OPNSENSE_*` env vars, however this was never implemented. This PR implements the logic to allow for this to work.

Fixes #39 