### PR TITLE
Fix firewall filter/nat not accepting aliases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-opnsense
 go 1.20
 
 require (
-	github.com/browningluke/opnsense-go v0.9.0
+	github.com/browningluke/opnsense-go v0.9.1
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/browningluke/opnsense-go v0.9.0 h1:0vSefSX4ZGrDp48zVIDWpU+akGN0UzqmWghiFyRJBBM=
-github.com/browningluke/opnsense-go v0.9.0/go.mod h1:8TRAG1xjiFzRUEuaosv4mHSXwBJd+R35o6QSEKGVwSA=
+github.com/browningluke/opnsense-go v0.9.1 h1:zUtoq+pcPN6EgsyU+GLUfr9O80T4dd0xmjKPGKGAn20=
+github.com/browningluke/opnsense-go v0.9.1/go.mod h1:8TRAG1xjiFzRUEuaosv4mHSXwBJd+R35o6QSEKGVwSA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/service/firewall_filter_schema.go
+++ b/internal/service/firewall_filter_schema.go
@@ -140,8 +140,8 @@ func FirewallFilterResourceSchema() schema.Schema {
 						Computed:            true,
 						Default:             stringdefault.StaticString(""),
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile("^(\\d|-)+$|^([a-z])+$"),
-								"must be number (80), range (80-443) or well known name (http)"),
+							stringvalidator.RegexMatches(regexp.MustCompile("^(\\d|-)+$|^(\\w){0,32}$"),
+								"must be number (80), range (80-443), well known name (http) or alias name"),
 						},
 					},
 					"invert": schema.BoolAttribute{
@@ -177,13 +177,13 @@ func FirewallFilterResourceSchema() schema.Schema {
 						Default:             stringdefault.StaticString("any"),
 					},
 					"port": schema.StringAttribute{
-						MarkdownDescription: "Destination port number or well known name (imap, imaps, http, https, ...), for ranges use a dash. Defaults to `\"\"`.",
+						MarkdownDescription: "Destination port number, well known name (imap, imaps, http, https, ...) or alias name, for ranges use a dash. Defaults to `\"\"`.",
 						Optional:            true,
 						Computed:            true,
 						Default:             stringdefault.StaticString(""),
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile("^(\\d|-)+$|^([a-z])+$"),
-								"must be number (80), range (80-443) or well known name (http)"),
+							stringvalidator.RegexMatches(regexp.MustCompile("^(\\d|-)+$|^(\\w){0,32}$"),
+								"must be number (80), range (80-443), well known name (http) or alias name"),
 						},
 					},
 					"invert": schema.BoolAttribute{

--- a/internal/service/firewall_nat_schema.go
+++ b/internal/service/firewall_nat_schema.go
@@ -157,8 +157,8 @@ func FirewallNATResourceSchema() schema.Schema {
 						Computed:            true,
 						Default:             stringdefault.StaticString(""),
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile("^(\\d|-)+$|^([a-z])+$"),
-								"must be number (80), range (80-443) or well known name (http)"),
+							stringvalidator.RegexMatches(regexp.MustCompile("^(\\d|-)+$|^(\\w){0,32}$"),
+								"must be number (80), range (80-443), well known name (http) or alias name"),
 						},
 					},
 					"invert": schema.BoolAttribute{


### PR DESCRIPTION
The existing validators for the `source` & `destination` blocks in the `os-firewall` plugin did not allow for aliases to be entered. These changes remedy that.
Ref #44

This PR also bumps the API version to v0.9.1, which fixes the reconfigure response issue for `os-wireguard`.
Ref #46 
