### PR TITLE
Feature/kea subnet match client ID

### DIFF
--- a/docs/data-sources/kea_subnet.md
+++ b/docs/data-sources/kea_subnet.md
@@ -26,6 +26,7 @@ Configure DHCP subnets for Kea.
 - `description` (String) Optional description here for your reference (not parsed).
 - `dns_servers` (Set of String) DNS servers to offer to the clients.
 - `domain_search` (Set of String) Set of Domain Names to be used by the client to locate not-fully-qualified domain names.
+- `match_client_id` (Boolean) By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations. Defaults to `true`.
 - `next_server` (String) Next server IP address.
 - `ntp_servers` (Set of String) Set of IP addresses indicating NTP (RFC 5905) servers available to the client.
 - `pools` (Set of String) Set of pools in range or subnet format (e.g. `"192.168.0.100 - 192.168.0.200"` , `"192.0.2.64/26"`).

--- a/docs/resources/kea_subnet.md
+++ b/docs/resources/kea_subnet.md
@@ -24,6 +24,8 @@ resource "opnsense_kea_subnet" "example" {
 
   next_server = "10.8.0.1"
 
+  match_client_id = false
+
   auto_collect = false
 
   static_routes = [
@@ -91,6 +93,7 @@ resource "opnsense_kea_subnet" "example" {
 - `dns_servers` (Set of String) DNS servers to offer to the clients. Defaults to `[]`.
 - `domain_name` (String) Domain name to offer to the client, set to this firewall's domain name when left empty. Defaults to `""`.
 - `domain_search` (Set of String) Set of Domain Names to be used by the client to locate not-fully-qualified domain names. Defaults to `[]`.
+- `match_client_id` (Boolean) By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations. Defaults to `true`.
 - `next_server` (String) Next server IP address. Defaults to `""`.
 - `ntp_servers` (Set of String) Set of IP addresses indicating NTP (RFC 5905) servers available to the client. Defaults to `[]`.
 - `pools` (Set of String) Set of pools in range or subnet format (e.g. `"192.168.0.100 - 192.168.0.200"` , `"192.0.2.64/26"`). Defaults to `[]`.

--- a/examples/resources/opnsense_kea_subnet/resource.tf
+++ b/examples/resources/opnsense_kea_subnet/resource.tf
@@ -10,6 +10,8 @@ resource "opnsense_kea_subnet" "example" {
 
   next_server = "10.8.0.1"
 
+  match_client_id = false
+
   auto_collect = false
 
   static_routes = [

--- a/internal/service/kea_subnet_schema.go
+++ b/internal/service/kea_subnet_schema.go
@@ -295,6 +295,7 @@ func convertKeaSubnetSchemaToStruct(d *KeaSubnetResourceModel) (*kea.Subnet, err
 		Subnet:                d.Subnet.ValueString(),
 		NextServer:            d.NextServer.ValueString(),
 		Pools:                 tools.SetToString(d.Pools, "\n"),
+		MatchClientId:         tools.BoolToString(d.MatchClientId.ValueBool()),
 		OptionDataAutoCollect: tools.BoolToString(d.AutoCollect.ValueBool()),
 		OptionData: kea.OptionData{
 			DomainNameServers: tools.SetToStringSlice(d.DomainNameServers),
@@ -315,6 +316,7 @@ func convertKeaSubnetStructToSchema(d *kea.Subnet) (*KeaSubnetResourceModel, err
 	model := &KeaSubnetResourceModel{
 		Subnet:            types.StringValue(d.Subnet),
 		Pools:             tools.StringSliceToSet(strings.Split(d.Pools, "\n")),
+		MatchClientId:     types.BoolValue(tools.StringToBool(d.MatchClientId)),
 		AutoCollect:       types.BoolValue(tools.StringToBool(d.OptionDataAutoCollect)),
 		Routers:           tools.StringSliceToSet(d.OptionData.Routers),
 		DomainNameServers: tools.StringSliceToSet(d.OptionData.DomainNameServers),

--- a/internal/service/kea_subnet_schema.go
+++ b/internal/service/kea_subnet_schema.go
@@ -72,7 +72,7 @@ func KeaSubnetResourceSchema() schema.Schema {
 				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
 			},
 			"match_client_id": schema.BoolAttribute{
-				MarkdownDescription: "By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations.",
+				MarkdownDescription: "By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations. Defaults to `true`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
@@ -205,7 +205,7 @@ func KeaSubnetDataSourceSchema() dschema.Schema {
 				ElementType:         types.StringType,
 			},
 			"match_client_id": dschema.BoolAttribute{
-				MarkdownDescription: "By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations.",
+				MarkdownDescription: "By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations. Defaults to `true`.",
 				Computed:            true,
 			},
 			"auto_collect": dschema.BoolAttribute{

--- a/internal/service/kea_subnet_schema.go
+++ b/internal/service/kea_subnet_schema.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"strings"
+	"terraform-provider-opnsense/internal/tools"
+
 	"github.com/browningluke/opnsense-go/pkg/kea"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -12,14 +15,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"strings"
-	"terraform-provider-opnsense/internal/tools"
 )
 
 // KeaSubnetResourceModel describes the resource data model.
 type KeaSubnetResourceModel struct {
 	Subnet types.String `tfsdk:"subnet"`
 	Pools  types.Set    `tfsdk:"pools"`
+
+	MatchClientId types.Bool `tfsdk:"match_client_id"`
 
 	AutoCollect types.Bool `tfsdk:"auto_collect"`
 
@@ -67,6 +70,12 @@ func KeaSubnetResourceSchema() schema.Schema {
 				Computed:            true,
 				ElementType:         types.StringType,
 				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"match_client_id": schema.BoolAttribute{
+				MarkdownDescription: "By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
 			},
 			"auto_collect": schema.BoolAttribute{
 				MarkdownDescription: "Automatically update option data from the GUI for relevant attributes. When set, values for `routers`, `dns_servers` and `ntp_servers` will be ignored. Defaults to `true`.",
@@ -194,6 +203,10 @@ func KeaSubnetDataSourceSchema() dschema.Schema {
 				MarkdownDescription: "Set of pools in range or subnet format (e.g. `\"192.168.0.100 - 192.168.0.200\"` , `\"192.0.2.64/26\"`).",
 				Computed:            true,
 				ElementType:         types.StringType,
+			},
+			"match_client_id": dschema.BoolAttribute{
+				MarkdownDescription: "By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations.",
+				Computed:            true,
 			},
 			"auto_collect": dschema.BoolAttribute{
 				MarkdownDescription: "Automatically update option data from the GUI for relevant attributes. When set, values for `routers`, `dns_servers` and `ntp_servers` will be ignored.",


### PR DESCRIPTION
Added the field match-client-id for kea subnet to be able to set this to false in my terraform projects. This is needed to get kea reservations working with matching on mac address instead of client-id.

For example when staging K8S Harvester nodes by PXE boot, the nodes changing their client-id during setup and like this, DHCP reservations are not working. I have to manually disable match-client-id in GUI during my Terraform apply run before Harvester nodes are starting.

I aslo adjusted your SDK opnensense-go (see pull request in this project: https://github.com/browningluke/opnsense-go/pull/32). Together with this change I am able to modify the corresponding field

<img width="606" height="604" alt="image" src="https://github.com/user-attachments/assets/782d7c9b-fc76-4f80-aa8f-187423ceca25" />
