### PR TITLE
fix: tftp spelling for kea subnet

### DIFF
--- a/docs/data-sources/kea_subnet.md
+++ b/docs/data-sources/kea_subnet.md
@@ -33,8 +33,8 @@ Configure DHCP subnets for Kea.
 - `routers` (Set of String) Default gateways to offer to the clients.
 - `static_routes` (Attributes Set) Static routes that the client should install in its routing cache. (see [below for nested schema](#nestedatt--static_routes))
 - `subnet` (String) Subnet in use (e.g. `"192.0.2.64/26"`).
-- `tfpt_server` (String) TFTP server address or fqdn.
 - `tftp_bootfile` (String) Boot filename to request.
+- `tftp_server` (String) TFTP server address or fqdn.
 - `time_servers` (Set of String) Set of RFC 868 time servers available to the client.
 
 <a id="nestedatt--static_routes"></a>

--- a/docs/resources/kea_subnet.md
+++ b/docs/resources/kea_subnet.md
@@ -99,8 +99,8 @@ resource "opnsense_kea_subnet" "example" {
 - `pools` (Set of String) Set of pools in range or subnet format (e.g. `"192.168.0.100 - 192.168.0.200"` , `"192.0.2.64/26"`). Defaults to `[]`.
 - `routers` (Set of String) Default gateways to offer to the clients. Defaults to `[]`.
 - `static_routes` (Attributes Set) Static routes that the client should install in its routing cache. Defaults to `[]`. (see [below for nested schema](#nestedatt--static_routes))
-- `tftp_server` (String) TFTP server address or fqdn. Defaults to `""`.
 - `tftp_bootfile` (String) Boot filename to request. Defaults to `""`.
+- `tftp_server` (String) TFTP server address or fqdn. Defaults to `""`.
 - `time_servers` (Set of String) Set of RFC 868 time servers available to the client. Defaults to `[]`.
 
 ### Read-Only

--- a/docs/resources/kea_subnet.md
+++ b/docs/resources/kea_subnet.md
@@ -72,7 +72,7 @@ resource "opnsense_kea_subnet" "example" {
     "10.10.101.11"
   ]
 
-  tfpt_server = "tfpt.example.com"
+  tftp_server = "tftp.example.com"
   tftp_bootfile = "bootfile.txt"
 
   description = "EXAMPLE"
@@ -99,7 +99,7 @@ resource "opnsense_kea_subnet" "example" {
 - `pools` (Set of String) Set of pools in range or subnet format (e.g. `"192.168.0.100 - 192.168.0.200"` , `"192.0.2.64/26"`). Defaults to `[]`.
 - `routers` (Set of String) Default gateways to offer to the clients. Defaults to `[]`.
 - `static_routes` (Attributes Set) Static routes that the client should install in its routing cache. Defaults to `[]`. (see [below for nested schema](#nestedatt--static_routes))
-- `tfpt_server` (String) TFTP server address or fqdn. Defaults to `""`.
+- `tftp_server` (String) TFTP server address or fqdn. Defaults to `""`.
 - `tftp_bootfile` (String) Boot filename to request. Defaults to `""`.
 - `time_servers` (Set of String) Set of RFC 868 time servers available to the client. Defaults to `[]`.
 

--- a/examples/resources/opnsense_kea_subnet/resource.tf
+++ b/examples/resources/opnsense_kea_subnet/resource.tf
@@ -58,7 +58,7 @@ resource "opnsense_kea_subnet" "example" {
     "10.10.101.11"
   ]
 
-  tfpt_server = "tfpt.example.com"
+  tftp_server = "tftp.example.com"
   tftp_bootfile = "bootfile.txt"
 
   description = "EXAMPLE"

--- a/internal/service/kea/subnet_schema.go
+++ b/internal/service/kea/subnet_schema.go
@@ -158,7 +158,7 @@ func subnetResourceSchema() schema.Schema {
 				Default:             stringdefault.StaticString(""),
 			},
 
-			"tfpt_server": schema.StringAttribute{
+			"tftp_server": schema.StringAttribute{
 				MarkdownDescription: "TFTP server address or fqdn. Defaults to `\"\"`.",
 				Optional:            true,
 				Computed:            true,
@@ -264,7 +264,7 @@ func subnetDataSourceSchema() dschema.Schema {
 				Computed:            true,
 			},
 
-			"tfpt_server": dschema.StringAttribute{
+			"tftp_server": dschema.StringAttribute{
 				MarkdownDescription: "TFTP server address or fqdn.",
 				Computed:            true,
 			},


### PR DESCRIPTION
## Description
Several wrong spelling of `tftp`, which this PR fixes - mostly effects the `opnsense_kea_subnet` resource.

## Related Issues
Related #71

## Type of Change
- [x] Bug fix
