### PR TITLE
Core Auth API support for OPNSense

### DIFF
--- a/.terraformrc.example
+++ b/.terraformrc.example
@@ -1,0 +1,17 @@
+provider_installation {
+
+  dev_overrides {
+    "dev.io/browningluke/opnsense" = "/home/{USER}/.terraform.d/plugins/dev.io/browningluke/opnsense/1.0.0/linux_amd64/"
+  }
+
+  filesystem_mirror {
+    path = "/home/{USER/.terraform.d/plugins/"
+    include = ["dev.io/*/*"]
+  }
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {
+    exclude = ["dev.io/*/*"]
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/browningluke/opnsense-go v0.14.0
+	github.com/browningluke/opnsense-go v0.15.0
 	github.com/hashicorp/terraform-plugin-docs v0.23.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/browningluke/opnsense-go v0.14.0 h1:1TCX6V4aZ7Yv0oftM3HQc6a7S0OjoJEzEo7fTYMjffQ=
-github.com/browningluke/opnsense-go v0.14.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
+github.com/browningluke/opnsense-go v0.15.0 h1:TS9KY+/kiutRAHLsA3LFb8ey3HCAGF00WgN9hZwKdmo=
+github.com/browningluke/opnsense-go v0.15.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/terraform-provider-opnsense/internal/service/auth"
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/diagnostics"
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/firewall"
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/interfaces"
@@ -283,6 +284,7 @@ func (p *opnsenseProvider) Configure(ctx context.Context, req provider.Configure
 
 func (p *opnsenseProvider) Resources(ctx context.Context) []func() resource.Resource {
 	controllers := [][]func() resource.Resource{
+		auth.Resources(ctx),
 		diagnostics.Resources(ctx),
 		firewall.Resources(ctx),
 		interfaces.Resources(ctx),
@@ -303,6 +305,7 @@ func (p *opnsenseProvider) Resources(ctx context.Context) []func() resource.Reso
 
 func (p *opnsenseProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	controllers := [][]func() datasource.DataSource{
+		auth.DataSources(ctx),
 		diagnostics.DataSources(ctx),
 		firewall.DataSources(ctx),
 		interfaces.DataSources(ctx),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/wireguard"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -28,6 +29,7 @@ import (
 
 // Ensure OPNsenseProvider satisfies various provider interfaces.
 var _ provider.Provider = &opnsenseProvider{}
+var _ provider.ProviderWithEphemeralResources = &opnsenseProvider{}
 
 // OPNsenseProvider defines the provider implementation.
 type opnsenseProvider struct {
@@ -280,6 +282,7 @@ func (p *opnsenseProvider) Configure(ctx context.Context, req provider.Configure
 
 	resp.DataSourceData = client
 	resp.ResourceData = client
+	resp.EphemeralResourceData = client
 }
 
 func (p *opnsenseProvider) Resources(ctx context.Context) []func() resource.Resource {
@@ -322,6 +325,19 @@ func (p *opnsenseProvider) DataSources(ctx context.Context) []func() datasource.
 		dataSources = append(dataSources, s...)
 	}
 	return dataSources
+}
+
+// EphemeralResources implements provider.ProviderWithEphemeralResources.
+func (p *opnsenseProvider) EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {
+	controllers := [][]func() ephemeral.EphemeralResource{
+		auth.EphemeralResources(ctx),
+	}
+
+	var ephemerals []func() ephemeral.EphemeralResource
+	for _, s := range controllers {
+		ephemerals = append(ephemerals, s...)
+	}
+	return ephemerals
 }
 
 func NewProvider(ctx context.Context) (provider.Provider, error) {

--- a/internal/service/auth/exports.go
+++ b/internal/service/auth/exports.go
@@ -1,0 +1,18 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func Resources(ctx context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		newUserResource,
+	}
+}
+
+func DataSources(ctx context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}

--- a/internal/service/auth/exports.go
+++ b/internal/service/auth/exports.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -15,4 +16,10 @@ func Resources(ctx context.Context) []func() resource.Resource {
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{}
+}
+
+func EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{
+		newUserPasswordEphemeral,
+	}
 }

--- a/internal/service/auth/user_password_resource.go
+++ b/internal/service/auth/user_password_resource.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ ephemeral.EphemeralResource = &userPasswordEphemeral{}
+var _ ephemeral.EphemeralResourceWithConfigure = &userPasswordEphemeral{}
+
+type userPasswordEphemeral struct {
+	client opnsense.Client
+}
+
+func newUserPasswordEphemeral() ephemeral.EphemeralResource {
+	return &userPasswordEphemeral{}
+}
+
+// Metadata implements ephemeral.EphemeralResource.
+func (u *userPasswordEphemeral) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_auth_user_password"
+}
+
+// Schema implements ephemeral.EphemeralResource.
+func (u *userPasswordEphemeral) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = userPasswordEphemeralSchema()
+}
+
+// Configure implements ephemeral.EphemeralResourceWithConfigure.
+func (u *userPasswordEphemeral) Configure(ctx context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	u.client = opnsense.NewClient(apiClient)
+}
+
+// Open implements ephemeral.EphemeralResource.
+func (u *userPasswordEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data userPasswordEphemeralModel
+
+	// Read Terraform config data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("\n%+v\n", data))
+
+	// Typically ephemeral resources will make external calls, however this example
+	// hardcodes setting the token attribute to a specific value for brevity.
+	// data.Password = data.Password
+
+	// Save data into ephemeral result data
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/internal/service/auth/user_password_schema.go
+++ b/internal/service/auth/user_password_schema.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type userPasswordEphemeralModel struct {
+	// Id       types.String `tfsdk:"id"`
+	Password types.String `tfsdk:"password"`
+}
+
+func userPasswordEphemeralSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "User Password ephemeral schema description",
+
+		Attributes: map[string]schema.Attribute{
+			// "id": schema.StringAttribute{
+			// 	Computed:            true,
+			// 	MarkdownDescription: "Id of the resource",
+			// },
+			"password": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Password of the user",
+				Sensitive:           true,
+			},
+		},
+	}
+}
+
+// func convertPasswordSchemaToStruct(scheme *userPasswordEphemeralModel) (*auth.User, error) {
+// 	return &auth.User{
+// 		// UserId:   scheme.Id.ValueString(),
+// 		Password: scheme.Password.ValueString(),
+// 	}, nil
+// }
+
+// func convertPasswordStructToSchema(strct *auth.User) (*userPasswordEphemeralModel, error) {
+// 	return &userPasswordEphemeralModel{
+// 		// Id:       types.StringValue(strct.UserId),
+// 		Password: types.StringValue(strct.Password),
+// 	}, nil
+// }

--- a/internal/service/auth/user_resource.go
+++ b/internal/service/auth/user_resource.go
@@ -1,0 +1,200 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &userResource{}
+var _ resource.ResourceWithConfigure = &userResource{}
+var _ resource.ResourceWithImportState = &userResource{}
+
+type userResource struct {
+	client opnsense.Client
+}
+
+func newUserResource() resource.Resource {
+	return &userResource{}
+}
+
+// Metadata implements resource.Resource.
+func (u *userResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_auth_user"
+}
+
+// Schema implements resource.Resource.
+func (u *userResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = userResourceSchema()
+}
+
+// Configure implements resource.ResourceWithConfigure.
+func (u *userResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	u.client = opnsense.NewClient(apiClient)
+}
+
+// ImportState implements resource.ResourceWithImportState.
+func (u *userResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Create implements resource.Resource.
+func (u *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *userResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert TF schema OPNsense struct
+	resourceStruct, err := convertUserSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse user, got error: %s", err))
+		return
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("%+v\n%+v\n", data, resourceStruct))
+
+	// Add firewall category to unbound
+	id, err := u.client.Auth().AddUser(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			// Tag new resource with ID from OPNsense
+			data.Id = types.StringValue(id)
+
+			// Save data into Terraform state
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to create user, got error: %s", err))
+		return
+	}
+
+	// Tag new resource with ID from OPNsense
+	data.Id = types.StringValue(id)
+
+	// Write logs using the tflog package
+	tflog.Trace(ctx, "created a resource")
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Read implements resource.Resource.
+func (u *userResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *userResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get firewall category from OPNsense unbound API
+	resourceStruct, err := u.client.Auth().GetUser(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "User not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read user, got error: %s", err))
+		return
+	}
+
+	// Convert OPNsense struct to TF schema
+	resourceModel, err := convertUserStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse user, got error: %s", err))
+		return
+	}
+
+	// ID cannot be added by convert... func, have to add here
+	resourceModel.Id = data.Id
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+// Update implements resource.Resource.
+func (u *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *userResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert TF schema OPNsense struct
+	resourceStruct, err := convertUserSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse user, got error: %s", err))
+		return
+	}
+
+	// Update firewall category in unbound
+	err = u.client.Auth().UpdateUser(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to update user, got error: %s", err))
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Delete implements resource.Resource.
+func (u *userResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *userResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := u.client.Auth().DeleteUser(ctx, data.Id.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to delete user, got error: %s", err))
+		return
+	}
+}

--- a/internal/service/auth/user_resource.go
+++ b/internal/service/auth/user_resource.go
@@ -81,6 +81,12 @@ func (u *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	tflog.Info(ctx, fmt.Sprintf("%+v\n%+v\n", data, resourceStruct))
 
+	var ephemeralPass types.String
+	req.Config.GetAttribute(ctx, path.Root("password"), &ephemeralPass)
+	resourceStruct.Password = ephemeralPass.ValueString()
+
+	tflog.Info(ctx, fmt.Sprintf("%+v\n%+v\n", data, resourceStruct))
+
 	// Add firewall category to unbound
 	id, err := u.client.Auth().AddUser(ctx, resourceStruct)
 	if err != nil {
@@ -143,6 +149,8 @@ func (u *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	// ID cannot be added by convert... func, have to add here
 	resourceModel.Id = data.Id
+
+	tflog.Info(ctx, fmt.Sprintf("\n%+v\n%+v\n%+v\n", data, resourceStruct, resourceModel))
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)

--- a/internal/service/auth/user_schema.go
+++ b/internal/service/auth/user_schema.go
@@ -43,6 +43,7 @@ func userResourceSchema() schema.Schema {
 				Required:            true,
 				MarkdownDescription: "Password of the user",
 				Sensitive:           true,
+				WriteOnly:           true,
 			},
 		},
 	}

--- a/internal/service/auth/user_schema.go
+++ b/internal/service/auth/user_schema.go
@@ -12,10 +12,11 @@ import (
 )
 
 type userResourceModel struct {
-	Id       types.String `tfsdk:"id"`
-	Disabled types.Bool   `tfsdk:"disabled"`
-	Name     types.String `tfsdk:"name"`
-	Password types.String `tfsdk:"password"`
+	Id              types.String `tfsdk:"id"`
+	Disabled        types.Bool   `tfsdk:"disabled"`
+	Name            types.String `tfsdk:"name"`
+	Password        types.String `tfsdk:"password_wo"`
+	PasswordVersion types.Int32  `tfsdk:"password_wo_version"`
 }
 
 func userResourceSchema() schema.Schema {
@@ -39,11 +40,18 @@ func userResourceSchema() schema.Schema {
 				Required:            true,
 				MarkdownDescription: "Name of the user",
 			},
-			"password": schema.StringAttribute{
+			"password_wo": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Password of the user",
 				Sensitive:           true,
 				WriteOnly:           true,
+			},
+			"password_wo_version": schema.Int32Attribute{
+				Required:            true,
+				MarkdownDescription: "Version of the password. Increment to update the password set on `password_wo`",
+				// PlanModifiers: []planmodifier.Int32{
+				// 	int32planmodifier.UseStateForUnknown(),
+				// },
 			},
 		},
 	}

--- a/internal/service/auth/user_schema.go
+++ b/internal/service/auth/user_schema.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"github.com/browningluke/opnsense-go/pkg/auth"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type userResourceModel struct {
+	Id       types.String `tfsdk:"id"`
+	Disabled types.Bool   `tfsdk:"disabled"`
+	Name     types.String `tfsdk:"name"`
+	Password types.String `tfsdk:"password"`
+}
+
+func userResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "User schema description",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Id of the resource",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"disabled": schema.BoolAttribute{
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "If user is disabled",
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Name of the user",
+			},
+			"password": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Password of the user",
+				Sensitive:           true,
+			},
+		},
+	}
+}
+
+func userDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "User data schema description",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Id of the resource",
+			},
+		},
+	}
+}
+
+func convertUserSchemaToStruct(scheme *userResourceModel) (*auth.User, error) {
+	return &auth.User{
+		UserId:   scheme.Id.ValueString(),
+		Disabled: tools.BoolToString(scheme.Disabled.ValueBool()),
+		Name:     scheme.Name.ValueString(),
+		Password: scheme.Password.ValueString(),
+	}, nil
+}
+
+func convertUserStructToSchema(strct *auth.User) (*userResourceModel, error) {
+	return &userResourceModel{
+		Id:       types.StringValue(strct.UserId),
+		Disabled: types.BoolValue(tools.StringToBool(strct.Disabled)),
+		Name:     types.StringValue(strct.Name),
+		Password: types.StringValue(strct.Password),
+	}, nil
+}


### PR DESCRIPTION
## Description
Add support for the Auth api endpoints from OPNsense-go client

## Related Issues
None at the moment

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
**Includes support for Ephemeral resources which require a specific Terraform CLI version**
- **Migration path**: 
  - Update Terraform CLI to minimum version: 1.10 or later
  - Update OpenTofu CLI to minimum version: v1.11 or later
- **v0 exception rationale** (if no schema migration):

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [ ] Or: v0 exception applies (explain why below)

**Explanation**:

## Testing
Describe how you tested your changes:
- [ ] Unit tests added/updated (optional, but encouraged)
- [x] Acceptance tests added/updated (mandatory)

## Examples
- [x] Examples added/updated in `examples/` directory
- [ ] N/A - No user-facing changes

## Environment
- **OPNsense version tested**: 
OPNsense 25.7.6-amd64
FreeBSD 14.3-RELEASE-p4
- **Terraform version**: tbd
- **OpenTofu version**: v1.11.0-beta1

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation has been generated (`make docs`)
- [ ] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [ ] Tests pass locally & in test workflow
