### PR TITLE
fix import of vlans

### DIFF
--- a/internal/service/interfaces/vlan_resource.go
+++ b/internal/service/interfaces/vlan_resource.go
@@ -128,7 +128,9 @@ func (r *vlanResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	// Handle empty device attribute (i.e. let OPNsense generate a device name)
 	// If the VLAN was created with device == "", then we ignore any changes to device.
-	if data.Device.ValueString() == "" {
+	// During import, data.Device is null (not empty string), so we skip this and
+	// keep the actual device value returned by the API.
+	if !data.Device.IsNull() && data.Device.ValueString() == "" {
 		vlanModel.Device = types.StringValue("")
 	}
 

--- a/internal/service/interfaces/vlan_resource_test.go
+++ b/internal/service/interfaces/vlan_resource_test.go
@@ -75,5 +75,5 @@ resource "opnsense_interfaces_vlan" "test" {
   parent      = %[4]q
   device      = %[5]q
 }
-`, tag, description, priority, parent)
+`, tag, description, priority, parent, device)
 }

--- a/internal/service/interfaces/vlan_resource_test.go
+++ b/internal/service/interfaces/vlan_resource_test.go
@@ -15,13 +15,14 @@ func TestAccInterfacesVlanResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccVlanResourceConfig(100, "High VLAN ID test", 4, "vtnet0"),
+				Config: testAccVlanResourceConfig(100, "High VLAN ID test", 4, "vtnet0", "vlan01"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+                    resource.TestCheckResourceAttrSet("opnsense_interfaces_vlan.test", "id"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "tag", "100"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "description", "High VLAN ID test"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "priority", "4"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "parent", "vtnet0"),
-					resource.TestCheckResourceAttrSet("opnsense_interfaces_vlan.test", "id"),
+					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "device", "vlan01"),
 				),
 			},
 			// ImportState testing
@@ -32,12 +33,13 @@ func TestAccInterfacesVlanResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: testAccVlanResourceConfig(100, "Updated VLAN 100", 6, "vtnet0"),
+				Config: testAccVlanResourceConfig(100, "Updated VLAN 100", 6, "vtnet0", "vlan01"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "tag", "100"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "description", "Updated VLAN 100"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "priority", "6"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "parent", "vtnet0"),
+					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "device", "vlan01"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -51,25 +53,27 @@ func TestAccInterfacesVlanResource_HighVlanId(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVlanResourceConfig(4093, "High VLAN ID test", 6, "vtnet0"),
+				Config: testAccVlanResourceConfig(4093, "High VLAN ID test", 6, "vtnet0", "vlan01"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "tag", "4093"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "description", "High VLAN ID test"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "priority", "6"),
 					resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "parent", "vtnet0"),
+                    resource.TestCheckResourceAttr("opnsense_interfaces_vlan.test", "device", "vlan01"),
 				),
 			},
 		},
 	})
 }
 
-func testAccVlanResourceConfig(tag int, description string, priority int, parent string) string {
+func testAccVlanResourceConfig(tag int, description string, priority int, parent string, device string) string {
 	return fmt.Sprintf(`
 resource "opnsense_interfaces_vlan" "test" {
   tag         = %[1]d
   description = %[2]q
   priority    = %[3]d
   parent      = %[4]q
+  device      = %[5]q
 }
 `, tag, description, priority, parent)
 }


### PR DESCRIPTION
## Description
Importing VLANs currently results in an unset device, which forces recreation during the next plan/apply. This fixes that. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
None (afaik)

## Schema Changes (if applicable)
None

**Explanation**:

## Testing
Describe how you tested your changes:
- `make build-local` and use the installed provider. 

## Examples
- [ ] Examples added/updated in `examples/` directory
- [x] N/A - No user-facing changes

## Environment
- **OPNsense version tested**: latest
- **Terraform version**: latest

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`)
- [ ] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [x] Tests pass locally & in test workflow
