### PR TITLE
Update OPNsense to 26.1 in test workflow

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -15,13 +15,15 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
-      - 'scripts/**'
-      - 'templates/**'
-      - 'README.md'
-      - '.github/**'
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!examples/**'
+      - '!scripts/**'
+      - '!templates/**'
+      - '!README.md'
+      - '!.github/**'
+      - '.github/workflows/terraform-test.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -27,9 +27,9 @@ permissions:
   contents: read
 
 env:
-  OPNSENSE_VERSION: "25.7"
-  OPNSENSE_URL: "https://files.bsd.ac/opnsense-qemu/opnsense-25.7.qcow2"
-  OPNSENSE_SHA1: edba9015951e68438fb6b0c0e1de21383bfaa399
+  OPNSENSE_VERSION: "26.1"
+  OPNSENSE_URL: "https://files.bsd.ac/opnsense-qemu/opnsense-26.1.qcow2"
+  OPNSENSE_SHA1: 2266a644b1669be1a8d916a0a79fc91ba4be4733
   OPNSENSE_SSH_PORT: 8022
   OPNSENSE_WEB_PORT: 8443
   TERRAFORM_PLUGIN_URI: "registry.terraform.io/browningluke/opnsense"


### PR DESCRIPTION
## Description
Update OPNsense to 26.1 in test workflow

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Chore

## Breaking Changes (if applicable)
- **What breaks**:
- **Migration path**:
- **v0 exception rationale** (if no schema migration):

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [ ] Or: v0 exception applies (explain why below)

**Explanation**:

## Testing
Describe how you tested your changes:
- [ ] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

## Examples
- [ ] Examples added/updated in `examples/` directory
- [ ] N/A - No user-facing changes

## Environment
- **OPNsense version tested**:
- **Terraform version**:

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation has been generated (`make docs`)
- [ ] Code has been formatted (`make fmt`)
- [ ] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [ ] Tests pass locally & in test workflow
