### PR TITLE
perf: replace sleep 180 with OPNsense health-check polling loop

### DIFF
--- a/.github/workflows/terraform-test-reusable.yml
+++ b/.github/workflows/terraform-test-reusable.yml
@@ -105,8 +105,20 @@ jobs:
           -nographic &
           QEMU_PID="$!"
           echo "qemu-pid=${QEMU_PID}" >> "$GITHUB_OUTPUT"
-          sleep 180 # Wait for the VM to boot
           [ -d "/proc/${QEMU_PID}" ] || (echo "QEMU process not found" && exit 1)
+      - name: Wait for OPNsense to be ready
+        run: |
+          echo "Waiting for OPNsense to be ready..."
+          for i in $(seq 1 60); do
+            if curl -sk --max-time 3 "https://localhost:${{ env.OPNSENSE_WEB_PORT }}/" | grep -q 'OPNsense'; then
+              echo "OPNsense ready after $((i * 5))s"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Timed out waiting for OPNsense after 300s" && exit 1
+            fi
+            sleep 5
+          done
       - name: Create API key
         id: apikey
         run: |


### PR DESCRIPTION
## Summary

Replaces the fixed `sleep 180` boot wait with a polling loop that proceeds as soon as OPNsense responds.

## Change

In `terraform-test-reusable.yml`, the `Start opnsense VM` step previously did a hard `sleep 180` to wait for the VM. This is replaced with a dedicated **"Wait for OPNsense to be ready"** step that:

- Polls `https://localhost:8443/` with `curl` every 5 seconds
- Proceeds immediately once it receives an OPNsense response
- Fails the job after 300 seconds if the VM never becomes ready

## Expected impact

OPNsense typically boots in 60–90 seconds on the GitHub-hosted runner. This change saves **~90–120 seconds per test run** with no structural pipeline changes.