### PR TITLE
feat: provision and cache OPNsense image before tests

### DIFF
--- a/.github/workflows/build-opnsense-image-reusable.yml
+++ b/.github/workflows/build-opnsense-image-reusable.yml
@@ -1,0 +1,93 @@
+name: Build OPNsense Image (reusable)
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+env:
+  OPNSENSE_VERSION: "26.1"
+  OPNSENSE_URL: "https://files.bsd.ac/opnsense-qemu/opnsense-26.1.qcow2"
+  OPNSENSE_SHA1: 2266a644b1669be1a8d916a0a79fc91ba4be4733
+  OPNSENSE_SSH_PORT: 8022
+  OPNSENSE_WEB_PORT: 8443
+
+jobs:
+  opnsense-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Restore OPNsense image cache
+        id: cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: opnsense-images
+          key: opnsense-image-${{ env.OPNSENSE_SHA1 }}-${{ hashFiles('scripts/upgrade-opnsense.py') }}
+      - name: Create opnsense image directory
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mkdir -p opnsense-images
+      - name: Download OPNsense image
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: curl -L "$OPNSENSE_URL" -o opnsense-images/opnsense.qcow2
+      - name: Verify OPNsense image
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: echo "$OPNSENSE_SHA1  opnsense-images/opnsense.qcow2" | sha1sum -c -
+      - name: Disable triggers
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /etc/dpkg/dpkg.cfg.d
+          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
+          path-exclude /usr/share/doc/*
+          path-exclude /usr/share/man/*
+          path-exclude /usr/share/info/*
+          EOF
+      - name: Install qemu
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+      - name: Start opnsense VM
+        if: steps.cache.outputs.cache-hit != 'true'
+        id: start-vm
+        run: |
+          qemu-system-x86_64 -m 6144 -smp 2 -hda opnsense-images/opnsense.qcow2 \
+          -netdev user,id=user.0,hostfwd=tcp::${{ env.OPNSENSE_SSH_PORT }}-:22,hostfwd=tcp::${{ env.OPNSENSE_WEB_PORT }}-:443 \
+          -device virtio-net,netdev=user.0 \
+          -chardev socket,path=/tmp/qemu-isa-serial.sock,server=on,wait=off,id=qga0 \
+          -device isa-serial,chardev=qga0 \
+          -device virtio-serial \
+          -chardev socket,path=/tmp/qemu-virtconsole.sock,server=on,wait=off,id=qvt0 \
+          -device virtconsole,chardev=qvt0 \
+          -chardev socket,path=/tmp/qemu-virtserialport.sock,server=on,wait=off,id=qvsp0 \
+          -device virtserialport,chardev=qvsp0,name=org.qemu.guest_agent.0 \
+          -nographic &
+          QEMU_PID="$!"
+          echo "qemu-pid=${QEMU_PID}" >> "$GITHUB_OUTPUT"
+          sleep 180 # Wait for the VM to boot
+          [ -d "/proc/${QEMU_PID}" ] || (echo "QEMU process not found" && exit 1)
+      - name: Upgrade OPNsense to latest 26.1.x patches
+        if: steps.cache.outputs.cache-hit != 'true'
+        # The bsd.ac image ships OPNsense 26.1 base. Multiple DNAT bugs
+        # were fixed in 26.1.1-26.1.3 (community changelog) that cause
+        # /api/firewall/d_nat/addRule to return 500. Apply patches first.
+        run: python3 scripts/upgrade-opnsense.py
+      - name: Shutdown OPNsense VM
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          python3 scripts/shutdown-opnsense.py
+          echo "Waiting for QEMU (PID ${{ steps.start-vm.outputs.qemu-pid }}) to exit..."
+          for i in $(seq 1 60); do
+            [ -d "/proc/${{ steps.start-vm.outputs.qemu-pid }}" ] || { echo "VM exited after $((i * 2))s"; break; }
+            sleep 2
+          done
+          [ -d "/proc/${{ steps.start-vm.outputs.qemu-pid }}" ] && kill -9 "${{ steps.start-vm.outputs.qemu-pid }}" || true
+      - name: Stop opnsense VM
+        if: always() && steps.start-vm.outputs.qemu-pid != ''
+        run: kill -9 ${{ steps.start-vm.outputs.qemu-pid }} || true
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: opnsense-image
+          path: opnsense-images

--- a/.github/workflows/build-opnsense-image.yml
+++ b/.github/workflows/build-opnsense-image.yml
@@ -12,8 +12,24 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
+  delete-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale OPNsense image caches
+        run: |
+          gh cache list --repo "$GITHUB_REPOSITORY" --json key \
+            --jq '.[] | select(.key | startswith("opnsense-image-")) | .key' | \
+            while IFS= read -r key; do
+              echo "Deleting cache: $key"
+              gh cache delete "$key" --repo "$GITHUB_REPOSITORY"
+            done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   opnsense-image:
+    needs: delete-cache
     uses: ./.github/workflows/build-opnsense-image-reusable.yml
 

--- a/.github/workflows/build-opnsense-image.yml
+++ b/.github/workflows/build-opnsense-image.yml
@@ -1,0 +1,19 @@
+name: Build OPNsense Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/upgrade-opnsense.py'
+  schedule:
+    - cron: '0 4 */7 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  opnsense-image:
+    uses: ./.github/workflows/build-opnsense-image-reusable.yml
+

--- a/.github/workflows/terraform-test-reusable.yml
+++ b/.github/workflows/terraform-test-reusable.yml
@@ -12,9 +12,6 @@ permissions:
   contents: read
 
 env:
-  OPNSENSE_VERSION: "26.1"
-  OPNSENSE_URL: "https://files.bsd.ac/opnsense-qemu/opnsense-26.1.qcow2"
-  OPNSENSE_SHA1: 2266a644b1669be1a8d916a0a79fc91ba4be4733
   OPNSENSE_SSH_PORT: 8022
   OPNSENSE_WEB_PORT: 8443
   TERRAFORM_PLUGIN_URI: "registry.terraform.io/browningluke/opnsense"
@@ -39,22 +36,7 @@ jobs:
           path: terraform-provider-opnsense
 
   opnsense-image:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create opnsense image directory
-        run: |
-          mkdir -p opnsense-images
-      - name: Download OPNsense image
-        run: |
-          curl -L "$OPNSENSE_URL" -o opnsense-images/opnsense.qcow2
-      - name: Verify OPNsense image
-        run: |
-          echo "$OPNSENSE_SHA1  opnsense-images/opnsense.qcow2" | sha1sum -c -
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: opnsense-image
-          path: opnsense-images
+    uses: ./.github/workflows/build-opnsense-image-reusable.yml
 
   test:
     runs-on: ubuntu-latest
@@ -74,9 +56,6 @@ jobs:
         run: |
           mkdir -p opnsense-images
           mv opnsense.qcow2 opnsense-images/
-      - name: Verify OPNsense image
-        run: |
-          echo "$OPNSENSE_SHA1  opnsense-images/opnsense.qcow2" | sha1sum -c -
       - name: Disable triggers
         run: |
           mkdir -p /etc/dpkg/dpkg.cfg.d
@@ -107,12 +86,28 @@ jobs:
           echo "qemu-pid=${QEMU_PID}" >> "$GITHUB_OUTPUT"
           sleep 180 # Wait for the VM to boot
           [ -d "/proc/${QEMU_PID}" ] || (echo "QEMU process not found" && exit 1)
-      - name: Upgrade OPNsense to latest 26.1.x patches
-        # The bsd.ac image ships OPNsense 26.1 base. Multiple DNAT bugs
-        # were fixed in 26.1.1-26.1.3 (community changelog) that cause
-        # /api/firewall/d_nat/addRule to return 500. Apply patches first.
+      - name: Wait for QEMU guest agent
         run: |
-          python3 scripts/upgrade-opnsense.py
+          python3 << 'EOF'
+          import json, os, select, socket, sys, time
+          SOCK = os.environ.get("QEMU_GA_SOCKET", "/tmp/qemu-virtserialport.sock")
+          deadline = time.monotonic() + 180
+          while time.monotonic() < deadline:
+              try:
+                  with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+                      s.settimeout(3)
+                      s.connect(SOCK)
+                      s.sendall((json.dumps({"execute": "guest-ping"}) + "\n").encode())
+                      ready, _, _ = select.select([s], [], [], 3)
+                      if ready and b'"return"' in s.recv(8192):
+                          print("Guest agent is ready", flush=True)
+                          sys.exit(0)
+              except Exception:
+                  pass
+              time.sleep(3)
+          print("ERROR: Guest agent not ready after 180s", file=sys.stderr)
+          sys.exit(1)
+          EOF
       - name: Create API key
         id: apikey
         run: |

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -1,5 +1,7 @@
 package firewall
 
+// NAT port forward schema for the opnsense_firewall_nat_port_forward resource.
+
 import (
 	"regexp"
 

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -1,7 +1,5 @@
 package firewall
 
-// NAT port forward schema for the opnsense_firewall_nat_port_forward resource.
-
 import (
 	"regexp"
 

--- a/scripts/shutdown-opnsense.py
+++ b/scripts/shutdown-opnsense.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Send a graceful power-off command to the QEMU-booted OPNsense VM."""
+
+import json
+import os
+import select
+import socket
+
+QEMU_GA_SOCKET = os.environ.get("QEMU_GA_SOCKET", "/tmp/qemu-virtserialport.sock")
+
+
+def send(command, timeout=10):
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout)
+        client.connect(QEMU_GA_SOCKET)
+        client.sendall((json.dumps(command) + "\n").encode())
+        chunks = b""
+        while True:
+            ready, _, _ = select.select([client], [], [], timeout)
+            if not ready:
+                break
+            chunk = client.recv(8192)
+            if not chunk:
+                break
+            chunks += chunk
+            if b"\n" in chunk:
+                break
+        return chunks.decode().strip()
+
+
+def main():
+    print("Sending power-off command via QEMU guest agent...", flush=True)
+    try:
+        resp = send({
+            "execute": "guest-exec",
+            "arguments": {
+                "path": "/sbin/shutdown",
+                "arg": ["-p", "now"],
+                "capture-output": False,
+            },
+        })
+        print(f"Response: {resp}", flush=True)
+    except Exception as exc:
+        print(f"Warning: could not send shutdown command: {exc}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Moves OPNsense image provisioning (download + upgrade) out of every test run and into a dedicated, cached build step.

## Changes

### New: `build-opnsense-image-reusable.yml`
Single source of truth for the full image build pipeline:
- Restores from cache (key: base-image SHA + `upgrade-opnsense.py` hash) — skips everything on a hit
- On cache miss: downloads + verifies the base image, boots QEMU, runs `upgrade-opnsense.py` to apply 26.1.x patches, then gracefully shuts down via `shutdown-opnsense.py` so the patched disk is flushed before caching
- Uploads the upgraded image as a workflow artifact

### New: `build-opnsense-image.yml`
Standalone workflow that calls the reusable to pre-warm the cache. Triggered by:
- Push to `main` when `scripts/upgrade-opnsense.py` changes
- 7-day schedule
- `workflow_dispatch` (manual rebuild via UI or `gh workflow run`)

### Modified: `terraform-test-reusable.yml`
- `opnsense-image` job replaced with a single `uses:` call to the reusable
- `test` job: removed the upgrade step and stale SHA1 verify; added a **Wait for QEMU guest agent** step instead
- Removed image-specific env vars (now owned by the reusable)

### New: `scripts/shutdown-opnsense.py`
Sends `/sbin/shutdown -p now` to the VM via the QEMU guest agent for a clean disk flush before the image is cached.

## Effect
On a warm cache, the `opnsense-image` job takes seconds instead of ~15 minutes. The cache is automatically invalidated when the base image URL/SHA or the upgrade script changes.