### PR TITLE
test: trigger CI for firewall nat port forward resource

### DIFF
--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -1,5 +1,7 @@
 package firewall
 
+// NAT port forward schema for the opnsense_firewall_nat_port_forward resource.
+
 import (
 	"regexp"
 


### PR DESCRIPTION
Dummy change to `nat_port_forward_schema.go` to trigger the PR test workflow for `./internal/service/firewall/...`.