### PR TITLE
ci: auto-bump opnsense-go version on release

### DIFF
--- a/.github/workflows/bump-opnsense-go.yml
+++ b/.github/workflows/bump-opnsense-go.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           VERSION: ${{ github.event.client_payload.version }}
         run: |
-          go get github.com/browningluke/opnsense-go@${VERSION}
+          go get "github.com/browningluke/opnsense-go@${VERSION}"
           go mod tidy
 
       - name: Open pull request

--- a/.github/workflows/bump-opnsense-go.yml
+++ b/.github/workflows/bump-opnsense-go.yml
@@ -1,0 +1,58 @@
+name: Bump opnsense-go Version
+
+on:
+  repository_dispatch:
+    types: [opnsense-go-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Bump opnsense-go
+        env:
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          go get github.com/browningluke/opnsense-go@${VERSION}
+          go mod tidy
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          VERSION: ${{ github.event.client_payload.version }}
+          RELEASE_URL: ${{ github.event.client_payload.release_url }}
+          RELEASE_NAME: ${{ github.event.client_payload.release_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "bump/opnsense-go-${VERSION}"
+          git add go.mod go.sum
+          git commit -m "chore(deps): bump opnsense-go to ${VERSION}"
+          git push origin "bump/opnsense-go-${VERSION}"
+
+          cat > /tmp/pr-body.md << EOF
+          Bumps \`github.com/browningluke/opnsense-go\` to \`${VERSION}\`.
+
+          This PR was opened automatically in response to a new release of [opnsense-go](${RELEASE_URL}).
+
+          **Release:** [${RELEASE_NAME}](${RELEASE_URL})
+          EOF
+
+          PR_URL=$(gh pr create \
+            --title "chore(deps): bump opnsense-go to ${VERSION}" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "bump/opnsense-go-${VERSION}")
+
+          gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

Adds a workflow that listens for a `repository_dispatch` event from `opnsense-go` and automatically opens a PR bumping the dependency version. Once CI passes, the PR auto-merges via squash commit.

## How it works

1. `opnsense-go` publishes a release and dispatches an `opnsense-go-release` event to this repo
2. This workflow runs `go get` and `go mod tidy` to update `go.mod` and `go.sum`
3. A PR is opened and configured for auto-merge (squash) — it merges automatically once all required checks pass

## Required setup

A secret named `AUTOMATION_TOKEN` must be added to this repository — the same fine-grained PAT used in `opnsense-go`, scoped to this repo with **Contents: Read & Write** and **Pull requests: Read & Write** permissions.

Additionally, **auto-merge must be enabled** on this repository: *Settings → General → Allow auto-merge*.