### PR TITLE
ci: add pre-test OPNsense configuration step

### DIFF
--- a/.github/workflows/terraform-test-reusable.yml
+++ b/.github/workflows/terraform-test-reusable.yml
@@ -120,6 +120,8 @@ jobs:
             echo "OPNSENSE_URI=https://localhost:${{ env.OPNSENSE_WEB_PORT }}";
             echo "OPNSENSE_ALLOW_INSECURE=true";
           } >> "$GITHUB_ENV"
+      - name: Configure OPNsense for tests
+        run: python3 scripts/configure-opnsense.py
       - name: Run terraform tests
         run: |
           env TF_ACC=1 go test -v -p 1 ${{ inputs.packages }}

--- a/scripts/configure-opnsense.py
+++ b/scripts/configure-opnsense.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Apply OPNsense pre-test configuration defined in opnsense-setup.jsonc.
+
+This script is called by CI before running acceptance tests. It reads a list
+of API calls from scripts/opnsense-setup.jsonc and executes them in order.
+
+To add or remove pre-conditions, edit opnsense-setup.jsonc — no Python
+changes required.
+
+Reads credentials from environment variables:
+  OPNSENSE_URI        - Base URL, e.g. https://localhost:8443
+  OPNSENSE_API_KEY    - API key
+  OPNSENSE_API_SECRET - API secret
+"""
+
+import json
+import os
+import pathlib
+import re
+import ssl
+import sys
+import urllib.request
+from base64 import b64encode
+
+SETUP_FILE = pathlib.Path(__file__).parent / "opnsense-setup.jsonc"
+
+
+def parse_jsonc(text):
+    """Parse JSON with C-style comments (// line and /* block */)."""
+    # Remove /* ... */ block comments
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    # Remove // line comments (not inside strings)
+    text = re.sub(r"//[^\n]*", "", text)
+    return json.loads(text)
+
+
+def api_post(base_url, key, secret, path, body):
+    url = base_url.rstrip("/") + path
+    credentials = b64encode(f"{key}:{secret}".encode()).decode()
+    headers = {
+        "Authorization": f"Basic {credentials}",
+        "Content-Type": "application/json",
+    }
+    # Allow self-signed certificates (mirrors AllowInsecure=true in tests)
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"HTTP {e.code}: {e.read().decode()}") from e
+
+
+def main():
+    base_url = os.environ.get("OPNSENSE_URI", "").rstrip("/")
+    key = os.environ.get("OPNSENSE_API_KEY", "")
+    secret = os.environ.get("OPNSENSE_API_SECRET", "")
+
+    if not base_url or not key or not secret:
+        print(
+            "ERROR: OPNSENSE_URI, OPNSENSE_API_KEY, and OPNSENSE_API_SECRET must be set",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    steps = parse_jsonc(SETUP_FILE.read_text())
+    print(f"Applying {len(steps)} setup step(s) to {base_url} ...")
+
+    errors = []
+    for step in steps:
+        desc = step["description"]
+        try:
+            result = api_post(base_url, key, secret, step["endpoint"], step["body"])
+            if result.get("result") not in ("saved", "ok"):
+                raise RuntimeError(f"unexpected result: {result}")
+            print(f"  [OK] {desc}")
+        except Exception as e:
+            print(f"  [FAIL] {desc}: {e}", file=sys.stderr)
+            errors.append(desc)
+
+    if errors:
+        print(f"\n{len(errors)} step(s) failed.", file=sys.stderr)
+        sys.exit(1)
+
+    print("Setup complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opnsense-setup.jsonc
+++ b/scripts/opnsense-setup.jsonc
@@ -9,34 +9,4 @@
 //   2. Add an entry below with a clear "description", the "endpoint", and the
 //      full "body" payload.
 //   No changes to configure-opnsense.py are needed.
-[
-  // ── Kea ──────────────────────────────────────────────────────────────────
-  {
-    "description": "Kea DHCPv4: register wan interface in general settings",
-    "endpoint": "/api/kea/dhcpv4/set",
-    "body": {
-      "dhcpv4": {
-        "general": {
-          "enabled": "0",
-          "interfaces": "wan",
-          "valid_lifetime": "4000",
-          "fwrules": "1"
-        }
-      }
-    }
-  },
-  {
-    "description": "Kea DHCPv6: register wan interface in general settings",
-    "endpoint": "/api/kea/dhcpv6/set",
-    "body": {
-      "dhcpv6": {
-        "general": {
-          "enabled": "0",
-          "interfaces": "wan",
-          "valid_lifetime": "4000",
-          "fwrules": "1"
-        }
-      }
-    }
-  }
-]
+[]

--- a/scripts/opnsense-setup.jsonc
+++ b/scripts/opnsense-setup.jsonc
@@ -1,0 +1,42 @@
+// OPNsense pre-test setup configuration for terraform-provider-opnsense
+//
+// Each entry is a POST request applied to the OPNsense API before acceptance
+// tests run. Entries are applied in order. If any entry fails, the CI step
+// fails immediately.
+//
+// To add a new pre-condition:
+//   1. Find the relevant API endpoint (GET the resource first to see its shape)
+//   2. Add an entry below with a clear "description", the "endpoint", and the
+//      full "body" payload.
+//   No changes to configure-opnsense.py are needed.
+[
+  // ── Kea ──────────────────────────────────────────────────────────────────
+  {
+    "description": "Kea DHCPv4: register wan interface in general settings",
+    "endpoint": "/api/kea/dhcpv4/set",
+    "body": {
+      "dhcpv4": {
+        "general": {
+          "enabled": "0",
+          "interfaces": "wan",
+          "valid_lifetime": "4000",
+          "fwrules": "1"
+        }
+      }
+    }
+  },
+  {
+    "description": "Kea DHCPv6: register wan interface in general settings",
+    "endpoint": "/api/kea/dhcpv6/set",
+    "body": {
+      "dhcpv6": {
+        "general": {
+          "enabled": "0",
+          "interfaces": "wan",
+          "valid_lifetime": "4000",
+          "fwrules": "1"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
Mirrors the pattern from `opnsense-go`: before running acceptance tests, apply a known configuration to OPNsense via its REST API.

## Changes

- `scripts/configure-opnsense.py` — copied verbatim from `opnsense-go`; reads `scripts/opnsense-setup.jsonc` and POSTs each entry in order
- `scripts/opnsense-setup.jsonc` — setup steps for the provider's tests (currently empty; Kea config will be added in a follow-up PR)
- `terraform-test-reusable.yml` — new **Configure OPNsense for tests** step added after credentials are exported and before tests run, matching the exact position used in `opnsense-go`'s workflow