### PR TITLE
Support multi-interface NAT port forwards

### DIFF
--- a/docs/data-sources/firewall_nat_port_forward.md
+++ b/docs/data-sources/firewall_nat_port_forward.md
@@ -23,7 +23,7 @@ Destination NAT (port forwarding) redirects traffic arriving on an external inte
 - `description` (String) Optional description for reference.
 - `destination` (Attributes) (see [below for nested schema](#nestedatt--destination))
 - `enabled` (Boolean) Whether this port forwarding rule is enabled.
-- `interface` (String) The interface on which packets must come in to match this rule.
+- `interface` (String) The interface or comma-separated interfaces on which packets must come in to match this rule.
 - `ip_protocol` (String) The Internet Protocol version this rule applies to. Available values: `inet`, `inet6`.
 - `log` (Boolean) Whether packets handled by this rule are logged.
 - `nat_reflection` (String) NAT reflection mode. One of `default`, `enable`, or `disable`.

--- a/docs/data-sources/firewall_nat_port_forward.md
+++ b/docs/data-sources/firewall_nat_port_forward.md
@@ -23,7 +23,7 @@ Destination NAT (port forwarding) redirects traffic arriving on an external inte
 - `description` (String) Optional description for reference.
 - `destination` (Attributes) (see [below for nested schema](#nestedatt--destination))
 - `enabled` (Boolean) Whether this port forwarding rule is enabled.
-- `interface` (String) The interface or comma-separated interfaces on which packets must come in to match this rule.
+- `interface` (Set of String) The interfaces on which packets must come in to match this rule.
 - `ip_protocol` (String) The Internet Protocol version this rule applies to. Available values: `inet`, `inet6`.
 - `log` (Boolean) Whether packets handled by this rule are logged.
 - `nat_reflection` (String) NAT reflection mode. One of `default`, `enable`, or `disable`.

--- a/docs/data-sources/interfaces_overview.md
+++ b/docs/data-sources/interfaces_overview.md
@@ -49,7 +49,7 @@ output "wan_ip" {
 - `ipv6` (Attributes List) IPv6 addresses assigned to the interface, including CARP virtual IPs. (see [below for nested schema](#nestedatt--ipv6))
 - `is_physical` (Boolean) Whether the interface is a physical interface.
 - `lagg_hash` (String) LAGG hash configuration.
-- `lagg_options` (String) LAGG options.
+- `lagg_options` (Attributes) LAGG options. (see [below for nested schema](#nestedatt--lagg_options))
 - `lagg_proto` (String) LAGG aggregation protocol (e.g. `"lacp"`).
 - `link_type` (String) Link type of the interface (e.g. `"ether"`, `"dhcp"`).
 - `macaddr` (String) Current MAC address of the interface.
@@ -91,6 +91,15 @@ Read-Only:
 - `peer` (String) CARP peer address.
 - `peer6` (String) CARP peer IPv6 address.
 - `vhid` (String) CARP virtual host ID.
+
+
+<a id="nestedatt--lagg_options"></a>
+### Nested Schema for `lagg_options`
+
+Read-Only:
+
+- `flags` (Set of String) LAGG option flags.
+- `flowid_shift` (String) LAGG flow ID shift.
 
 
 <a id="nestedatt--vlan"></a>

--- a/docs/data-sources/interfaces_overview_all.md
+++ b/docs/data-sources/interfaces_overview_all.md
@@ -64,7 +64,7 @@ Read-Only:
 - `ipv6` (Attributes List) IPv6 addresses assigned to the interface, including CARP virtual IPs. (see [below for nested schema](#nestedatt--interfaces--ipv6))
 - `is_physical` (Boolean) Whether the interface is a physical interface.
 - `lagg_hash` (String) LAGG hash configuration.
-- `lagg_options` (String) LAGG options.
+- `lagg_options` (Attributes) LAGG options. (see [below for nested schema](#nestedatt--interfaces--lagg_options))
 - `lagg_proto` (String) LAGG aggregation protocol (e.g. `"lacp"`).
 - `link_type` (String) Link type of the interface (e.g. `"ether"`, `"dhcp"`).
 - `macaddr` (String) Current MAC address of the interface.
@@ -106,6 +106,15 @@ Read-Only:
 - `peer` (String) CARP peer address.
 - `peer6` (String) CARP peer IPv6 address.
 - `vhid` (String) CARP virtual host ID.
+
+
+<a id="nestedatt--interfaces--lagg_options"></a>
+### Nested Schema for `interfaces.lagg_options`
+
+Read-Only:
+
+- `flags` (Set of String) LAGG option flags.
+- `flowid_shift` (String) LAGG flow ID shift.
 
 
 <a id="nestedatt--interfaces--vlan"></a>

--- a/docs/resources/firewall_nat_port_forward.md
+++ b/docs/resources/firewall_nat_port_forward.md
@@ -17,7 +17,7 @@ Destination NAT (port forwarding) redirects traffic arriving on an external inte
 resource "opnsense_firewall_nat_port_forward" "wan_https_k3s_ingress" {
   enabled     = true
   sequence    = 100
-  interface   = "wan"
+  interface   = ["wan"]
   ip_protocol = "inet"
   protocol    = "tcp"
 
@@ -44,7 +44,7 @@ resource "opnsense_firewall_nat_port_forward" "wan_https_k3s_ingress" {
 
 ### Required
 
-- `interface` (String) Choose on which interface packets must come in to match this rule. Multiple interfaces may be specified as a comma-separated list.
+- `interface` (Set of String) Choose on which interface packets must come in to match this rule. Must specify at least 1.
 - `protocol` (String) Choose which IP protocol this rule should match.
 - `target` (Attributes) (see [below for nested schema](#nestedatt--target))
 

--- a/docs/resources/firewall_nat_port_forward.md
+++ b/docs/resources/firewall_nat_port_forward.md
@@ -44,7 +44,7 @@ resource "opnsense_firewall_nat_port_forward" "wan_https_k3s_ingress" {
 
 ### Required
 
-- `interface` (String) Choose on which interface packets must come in to match this rule.
+- `interface` (String) Choose on which interface packets must come in to match this rule. Multiple interfaces may be specified as a comma-separated list.
 - `protocol` (String) Choose which IP protocol this rule should match.
 - `target` (Attributes) (see [below for nested schema](#nestedatt--target))
 

--- a/examples/resources/opnsense_firewall_nat_port_forward/resource.tf
+++ b/examples/resources/opnsense_firewall_nat_port_forward/resource.tf
@@ -1,7 +1,7 @@
 resource "opnsense_firewall_nat_port_forward" "wan_https_k3s_ingress" {
   enabled     = true
   sequence    = 100
-  interface   = "wan"
+  interface   = ["wan"]
   ip_protocol = "inet"
   protocol    = "tcp"
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/browningluke/terraform-provider-opnsense
 go 1.25.8
 
 require (
-	github.com/browningluke/opnsense-go v0.18.0
+	github.com/browningluke/opnsense-go v0.19.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -88,5 +88,3 @@ require (
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/browningluke/opnsense-go => github.com/stoffus/opnsense-go v0.18.1-0.20260601141411-cdf2177ba1d7

--- a/go.mod
+++ b/go.mod
@@ -88,3 +88,5 @@ require (
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/browningluke/opnsense-go => github.com/stoffus/opnsense-go v0.18.1-0.20260601141411-cdf2177ba1d7

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/browningluke/opnsense-go v0.18.0 h1:pFciyRVYVObGx90lHIUhBnSFgwCZqmfzMbCZVElRIVo=
+github.com/browningluke/opnsense-go v0.18.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -187,8 +189,6 @@ github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQ
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
-github.com/stoffus/opnsense-go v0.18.1-0.20260601141411-cdf2177ba1d7 h1:NnEoBSy1Ix9J2vavYOUxDUaSWntl90KMVuwdJmMaqdE=
-github.com/stoffus/opnsense-go v0.18.1-0.20260601141411-cdf2177ba1d7/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/browningluke/opnsense-go v0.18.0 h1:pFciyRVYVObGx90lHIUhBnSFgwCZqmfzMbCZVElRIVo=
-github.com/browningluke/opnsense-go v0.18.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
+github.com/browningluke/opnsense-go v0.19.0 h1:ioEpQZUNdi9XnebIp0p//+kh5iA2H9hqHj2IpcorL+g=
+github.com/browningluke/opnsense-go v0.19.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/browningluke/opnsense-go v0.18.0 h1:pFciyRVYVObGx90lHIUhBnSFgwCZqmfzMbCZVElRIVo=
-github.com/browningluke/opnsense-go v0.18.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -189,6 +187,8 @@ github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQ
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
+github.com/stoffus/opnsense-go v0.18.1-0.20260601141411-cdf2177ba1d7 h1:NnEoBSy1Ix9J2vavYOUxDUaSWntl90KMVuwdJmMaqdE=
+github.com/stoffus/opnsense-go v0.18.1-0.20260601141411-cdf2177ba1d7/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/service/firewall/nat_port_forward_resource.go
+++ b/internal/service/firewall/nat_port_forward_resource.go
@@ -18,6 +18,7 @@ import (
 var _ resource.Resource = &natPortForwardResource{}
 var _ resource.ResourceWithConfigure = &natPortForwardResource{}
 var _ resource.ResourceWithImportState = &natPortForwardResource{}
+var _ resource.ResourceWithUpgradeState = &natPortForwardResource{}
 
 func newNATPortForwardResource() resource.Resource {
 	return &natPortForwardResource{}
@@ -189,4 +190,48 @@ func (r *natPortForwardResource) Delete(ctx context.Context, req resource.Delete
 
 func (r *natPortForwardResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *natPortForwardResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV1 := natPortForwardResourceSchemaV1()
+	return map[int64]resource.StateUpgrader{
+		1: {
+			PriorSchema:   &schemaV1,
+			StateUpgrader: upgradeNATPortForwardStateV1toV2,
+		},
+	}
+}
+
+func upgradeNATPortForwardStateV1toV2(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	tflog.Info(ctx, "Upgrading NAT port forward resource state from v1 to v2")
+
+	var oldState natPortForwardResourceModelV1
+	resp.Diagnostics.Append(req.State.Get(ctx, &oldState)...)
+	if resp.Diagnostics.HasError() {
+		tflog.Error(ctx, "Failed to read old NAT port forward state during upgrade")
+		return
+	}
+
+	newState := &natPortForwardResourceModel{
+		Enabled:       oldState.Enabled,
+		Sequence:      oldState.Sequence,
+		Interface:     natPortForwardInterfaceStringToSet(oldState.Interface.ValueString()),
+		IPProtocol:    oldState.IPProtocol,
+		Protocol:      oldState.Protocol,
+		Source:        oldState.Source,
+		Destination:   oldState.Destination,
+		Target:        oldState.Target,
+		Log:           oldState.Log,
+		NatReflection: oldState.NatReflection,
+		Description:   oldState.Description,
+		Id:            oldState.Id,
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+
+	if !resp.Diagnostics.HasError() {
+		tflog.Info(ctx, "Successfully upgraded NAT port forward resource state from v1 to v2", map[string]any{
+			"id": oldState.Id.ValueString(),
+		})
+	}
 }

--- a/internal/service/firewall/nat_port_forward_resource_test.go
+++ b/internal/service/firewall/nat_port_forward_resource_test.go
@@ -16,7 +16,7 @@ func TestAccFirewallNatPortForwardResource(t *testing.T) {
 			// Create and Read testing
 			{
 				Config: testAccFirewallNatPortForwardResourceConfig(
-					true, false, 100, "wan", "inet", "tcp",
+					true, false, 100, `["wan"]`, "inet", "tcp",
 					"192.168.1.0/24", "1024", false,
 					"10.10.10.22/32", "8080", false,
 					"192.168.10.10", "80",
@@ -26,7 +26,8 @@ func TestAccFirewallNatPortForwardResource(t *testing.T) {
 					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "log", "false"),
 					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "sequence", "100"),
-					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "interface", "wan"),
+					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "interface.#", "1"),
+					resource.TestCheckTypeSetElemAttr("opnsense_firewall_nat_port_forward.test", "interface.*", "wan"),
 					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "ip_protocol", "inet"),
 					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "protocol", "tcp"),
 					resource.TestCheckResourceAttr("opnsense_firewall_nat_port_forward.test", "source.net", "192.168.1.0/24"),
@@ -51,7 +52,7 @@ func TestAccFirewallNatPortForwardResource(t *testing.T) {
 			// Update and Read testing
 			{
 				Config: testAccFirewallNatPortForwardResourceConfig(
-					false, true, 200, "wan", "inet", "udp",
+					false, true, 200, `["wan"]`, "inet", "udp",
 					"10.0.0.0/8", "1024-65535", true,
 					"10.10.10.23/32", "53", true,
 					"192.168.10.20", "53",
@@ -92,7 +93,7 @@ func TestAccFirewallNatPortForwardReflectionResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFirewallNatPortForwardResourceConfig(
-					true, false, 1, "wan", "inet", "tcp",
+					true, false, 1, `["wan"]`, "inet", "tcp",
 					"", "", false,
 					"10.10.10.30/32", "4443", false,
 					"192.168.10.30", "443",
@@ -104,7 +105,7 @@ func TestAccFirewallNatPortForwardReflectionResource(t *testing.T) {
 			},
 			{
 				Config: testAccFirewallNatPortForwardResourceConfig(
-					true, false, 1, "wan", "inet", "tcp",
+					true, false, 1, `["wan"]`, "inet", "tcp",
 					"", "", false,
 					"10.10.10.30/32", "4443", false,
 					"192.168.10.30", "443",
@@ -123,7 +124,7 @@ func TestAccFirewallNatPortForwardReflectionResource(t *testing.T) {
 			},
 			{
 				Config: testAccFirewallNatPortForwardResourceConfig(
-					true, false, 1, "wan", "inet", "tcp",
+					true, false, 1, `["wan"]`, "inet", "tcp",
 					"", "", false,
 					"10.10.10.30/32", "4443", false,
 					"192.168.10.30", "443",
@@ -164,7 +165,7 @@ resource "opnsense_firewall_nat_port_forward" "test" {
   enabled     = %[1]t
   log         = %[2]t
   sequence    = %[3]d
-  interface   = %[4]q
+  interface   = %[4]s
   ip_protocol = %[5]q
   protocol    = %[6]q%[7]s
   destination = {

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -2,6 +2,7 @@ package firewall
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/firewall"
@@ -60,7 +61,7 @@ func natPortForwardResourceSchema() schema.Schema {
 				Default:             int64default.StaticInt64(1),
 			},
 			"interface": schema.StringAttribute{
-				MarkdownDescription: "Choose on which interface packets must come in to match this rule.",
+				MarkdownDescription: "Choose on which interface packets must come in to match this rule. Multiple interfaces may be specified as a comma-separated list.",
 				Required:            true,
 			},
 			"ip_protocol": schema.StringAttribute{
@@ -234,7 +235,7 @@ func natPortForwardDataSourceSchema() dschema.Schema {
 				Computed:            true,
 			},
 			"interface": dschema.StringAttribute{
-				MarkdownDescription: "The interface on which packets must come in to match this rule.",
+				MarkdownDescription: "The interface or comma-separated interfaces on which packets must come in to match this rule.",
 				Computed:            true,
 			},
 			"ip_protocol": dschema.StringAttribute{
@@ -334,12 +335,23 @@ func natReflectionAPIToSchema(s string) string {
 	}
 }
 
+func natPortForwardInterfaceSchemaToAPI(s string) api.SelectedMap {
+	var interfaces []string
+	for _, iface := range strings.Split(s, ",") {
+		iface = strings.TrimSpace(iface)
+		if iface != "" {
+			interfaces = append(interfaces, iface)
+		}
+	}
+	return api.SelectedMap(strings.Join(interfaces, ","))
+}
+
 func convertNATPortForwardSchemaToStruct(d *natPortForwardResourceModel) (*firewall.NatPortForward, error) {
 	return &firewall.NatPortForward{
 		// Schema uses "enabled" (user-friendly), API uses "disabled" (inverted).
 		Disabled:   tools.BoolToString(!d.Enabled.ValueBool()),
 		Sequence:   tools.Int64ToString(d.Sequence.ValueInt64()),
-		Interface:  api.SelectedMap(d.Interface.ValueString()),
+		Interface:  natPortForwardInterfaceSchemaToAPI(d.Interface.ValueString()),
 		IPProtocol: api.SelectedMap(d.IPProtocol.ValueString()),
 		Protocol:   api.SelectedMap(d.Protocol.ValueString()),
 		Source: firewall.NatPortForwardLocation{

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -373,11 +373,11 @@ func natReflectionAPIToSchema(s string) string {
 	}
 }
 
-func natPortForwardInterfaceSchemaToAPI(s types.Set) api.SelectedMapList {
+func natPortForwardInterfaceSchemaToAPI(s types.Set) api.SelectedMap {
 	var interfaces []string
 	s.ElementsAs(context.Background(), &interfaces, false)
 	sort.Strings(interfaces)
-	return api.SelectedMapList(interfaces)
+	return api.SelectedMap(strings.Join(interfaces, ","))
 }
 
 func natPortForwardInterfaceStringToSet(s string) types.Set {
@@ -431,7 +431,7 @@ func convertNATPortForwardStructToSchema(d *firewall.NatPortForward) (*natPortFo
 		// API uses "disabled" (inverted), schema uses "enabled" (user-friendly).
 		Enabled:    types.BoolValue(!tools.StringToBool(d.Disabled)),
 		Sequence:   tools.StringToInt64Null(d.Sequence),
-		Interface:  tools.StringSliceToSet([]string(d.Interface)),
+		Interface:  natPortForwardInterfaceStringToSet(d.Interface.String()),
 		IPProtocol: types.StringValue(d.IPProtocol.String()),
 		Protocol:   types.StringValue(d.Protocol.String()),
 		Source: &firewallLocation{

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -1,12 +1,15 @@
 package firewall
 
 import (
+	"context"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/firewall"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -23,6 +26,26 @@ import (
 
 // natPortForwardResourceModel describes the resource data model.
 type natPortForwardResourceModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+
+	Sequence  types.Int64 `tfsdk:"sequence"`
+	Interface types.Set   `tfsdk:"interface"`
+
+	IPProtocol types.String `tfsdk:"ip_protocol"`
+	Protocol   types.String `tfsdk:"protocol"`
+
+	Source      *firewallLocation `tfsdk:"source"`
+	Destination *firewallLocation `tfsdk:"destination"`
+	Target      *firewallTarget   `tfsdk:"target"`
+
+	Log           types.Bool   `tfsdk:"log"`
+	NatReflection types.String `tfsdk:"nat_reflection"`
+	Description   types.String `tfsdk:"description"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+type natPortForwardResourceModelV1 struct {
 	Enabled types.Bool `tfsdk:"enabled"`
 
 	Sequence  types.Int64  `tfsdk:"sequence"`
@@ -44,7 +67,7 @@ type natPortForwardResourceModel struct {
 
 func natPortForwardResourceSchema() schema.Schema {
 	return schema.Schema{
-		Version:             1,
+		Version:             2,
 		MarkdownDescription: "Destination NAT (port forwarding) redirects traffic arriving on an external interface to an internal host. Use this to expose internal services (e.g. web servers, SSH) to the outside network.",
 
 		Attributes: map[string]schema.Attribute{
@@ -60,9 +83,13 @@ func natPortForwardResourceSchema() schema.Schema {
 				Computed:            true,
 				Default:             int64default.StaticInt64(1),
 			},
-			"interface": schema.StringAttribute{
-				MarkdownDescription: "Choose on which interface packets must come in to match this rule. Multiple interfaces may be specified as a comma-separated list.",
+			"interface": schema.SetAttribute{
+				MarkdownDescription: "Choose on which interface packets must come in to match this rule. Must specify at least 1.",
 				Required:            true,
+				ElementType:         types.StringType,
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+				},
 			},
 			"ip_protocol": schema.StringAttribute{
 				MarkdownDescription: "Select the Internet Protocol version this rule applies to. Available values: `inet`, `inet6`. Defaults to `inet`.",
@@ -217,6 +244,16 @@ func natPortForwardResourceSchema() schema.Schema {
 	}
 }
 
+func natPortForwardResourceSchemaV1() schema.Schema {
+	s := natPortForwardResourceSchema()
+	s.Version = 1
+	s.Attributes["interface"] = schema.StringAttribute{
+		MarkdownDescription: "Choose on which interface packets must come in to match this rule.",
+		Required:            true,
+	}
+	return s
+}
+
 func natPortForwardDataSourceSchema() dschema.Schema {
 	return dschema.Schema{
 		MarkdownDescription: "Destination NAT (port forwarding) redirects traffic arriving on an external interface to an internal host. Use this to expose internal services (e.g. web servers, SSH) to the outside network.",
@@ -234,9 +271,10 @@ func natPortForwardDataSourceSchema() dschema.Schema {
 				MarkdownDescription: "The order of this port forwarding rule.",
 				Computed:            true,
 			},
-			"interface": dschema.StringAttribute{
-				MarkdownDescription: "The interface or comma-separated interfaces on which packets must come in to match this rule.",
+			"interface": dschema.SetAttribute{
+				MarkdownDescription: "The interfaces on which packets must come in to match this rule.",
 				Computed:            true,
+				ElementType:         types.StringType,
 			},
 			"ip_protocol": dschema.StringAttribute{
 				MarkdownDescription: "The Internet Protocol version this rule applies to. Available values: `inet`, `inet6`.",
@@ -335,15 +373,22 @@ func natReflectionAPIToSchema(s string) string {
 	}
 }
 
-func natPortForwardInterfaceSchemaToAPI(s string) api.SelectedMap {
+func natPortForwardInterfaceSchemaToAPI(s types.Set) api.SelectedMapList {
 	var interfaces []string
+	s.ElementsAs(context.Background(), &interfaces, false)
+	sort.Strings(interfaces)
+	return api.SelectedMapList(interfaces)
+}
+
+func natPortForwardInterfaceStringToSet(s string) types.Set {
+	var interfaces []attr.Value
 	for _, iface := range strings.Split(s, ",") {
 		iface = strings.TrimSpace(iface)
 		if iface != "" {
-			interfaces = append(interfaces, iface)
+			interfaces = append(interfaces, types.StringValue(iface))
 		}
 	}
-	return api.SelectedMap(strings.Join(interfaces, ","))
+	return types.SetValueMust(types.StringType, interfaces)
 }
 
 func convertNATPortForwardSchemaToStruct(d *natPortForwardResourceModel) (*firewall.NatPortForward, error) {
@@ -351,7 +396,7 @@ func convertNATPortForwardSchemaToStruct(d *natPortForwardResourceModel) (*firew
 		// Schema uses "enabled" (user-friendly), API uses "disabled" (inverted).
 		Disabled:   tools.BoolToString(!d.Enabled.ValueBool()),
 		Sequence:   tools.Int64ToString(d.Sequence.ValueInt64()),
-		Interface:  natPortForwardInterfaceSchemaToAPI(d.Interface.ValueString()),
+		Interface:  natPortForwardInterfaceSchemaToAPI(d.Interface),
 		IPProtocol: api.SelectedMap(d.IPProtocol.ValueString()),
 		Protocol:   api.SelectedMap(d.Protocol.ValueString()),
 		Source: firewall.NatPortForwardLocation{
@@ -386,7 +431,7 @@ func convertNATPortForwardStructToSchema(d *firewall.NatPortForward) (*natPortFo
 		// API uses "disabled" (inverted), schema uses "enabled" (user-friendly).
 		Enabled:    types.BoolValue(!tools.StringToBool(d.Disabled)),
 		Sequence:   tools.StringToInt64Null(d.Sequence),
-		Interface:  types.StringValue(d.Interface.String()),
+		Interface:  tools.StringSliceToSet([]string(d.Interface)),
 		IPProtocol: types.StringValue(d.IPProtocol.String()),
 		Protocol:   types.StringValue(d.Protocol.String()),
 		Source: &firewallLocation{

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -373,11 +373,11 @@ func natReflectionAPIToSchema(s string) string {
 	}
 }
 
-func natPortForwardInterfaceSchemaToAPI(s types.Set) api.SelectedMap {
+func natPortForwardInterfaceSchemaToAPI(s types.Set) api.SelectedMapList {
 	var interfaces []string
 	s.ElementsAs(context.Background(), &interfaces, false)
 	sort.Strings(interfaces)
-	return api.SelectedMap(strings.Join(interfaces, ","))
+	return api.SelectedMapList(interfaces)
 }
 
 func natPortForwardInterfaceStringToSet(s string) types.Set {
@@ -431,7 +431,7 @@ func convertNATPortForwardStructToSchema(d *firewall.NatPortForward) (*natPortFo
 		// API uses "disabled" (inverted), schema uses "enabled" (user-friendly).
 		Enabled:    types.BoolValue(!tools.StringToBool(d.Disabled)),
 		Sequence:   tools.StringToInt64Null(d.Sequence),
-		Interface:  natPortForwardInterfaceStringToSet(d.Interface.String()),
+		Interface:  tools.StringSliceToSet([]string(d.Interface)),
 		IPProtocol: types.StringValue(d.IPProtocol.String()),
 		Protocol:   types.StringValue(d.Protocol.String()),
 		Source: &firewallLocation{

--- a/internal/service/firewall/nat_port_forward_schema_test.go
+++ b/internal/service/firewall/nat_port_forward_schema_test.go
@@ -55,6 +55,38 @@ func TestConvertNATPortForwardSchemaToStruct(t *testing.T) {
 	require.Equal(t, "WAN HTTPS to k3s Traefik ingress VIP", result.Description)
 }
 
+func TestConvertNATPortForwardSchemaToStructWithMultipleInterfaces(t *testing.T) {
+	data := &natPortForwardResourceModel{
+		Enabled:    types.BoolValue(true),
+		Sequence:   types.Int64Value(100),
+		Interface:  types.StringValue("wan, openvpn"),
+		IPProtocol: types.StringValue("inet"),
+		Protocol:   types.StringValue("tcp"),
+		Source: &firewallLocation{
+			Net:    types.StringValue("any"),
+			Port:   types.StringValue(""),
+			Invert: types.BoolValue(false),
+		},
+		Destination: &firewallLocation{
+			Net:    types.StringValue("wanip"),
+			Port:   types.StringValue("443"),
+			Invert: types.BoolValue(false),
+		},
+		Target: &firewallTarget{
+			IP:   types.StringValue("10.1.1.20"),
+			Port: types.StringValue("443"),
+		},
+		Log:           types.BoolValue(false),
+		NatReflection: types.StringValue("default"),
+		Description:   types.StringValue("WAN HTTPS to k3s Traefik ingress VIP"),
+	}
+
+	result, err := convertNATPortForwardSchemaToStruct(data)
+
+	require.NoError(t, err)
+	require.Equal(t, "wan,openvpn", result.Interface.String())
+}
+
 func TestConvertNATPortForwardStructToSchema(t *testing.T) {
 	result, err := convertNATPortForwardStructToSchema(&opnfirewall.NatPortForward{
 		Disabled:   "1",

--- a/internal/service/firewall/nat_port_forward_schema_test.go
+++ b/internal/service/firewall/nat_port_forward_schema_test.go
@@ -97,7 +97,7 @@ func TestConvertNATPortForwardStructToSchema(t *testing.T) {
 	result, err := convertNATPortForwardStructToSchema(&opnfirewall.NatPortForward{
 		Disabled:   "1",
 		Sequence:   "200",
-		Interface:  api.SelectedMap("wan"),
+		Interface:  api.SelectedMapList{"wan"},
 		IPProtocol: "inet",
 		Protocol:   "tcp",
 		Source: opnfirewall.NatPortForwardLocation{

--- a/internal/service/firewall/nat_port_forward_schema_test.go
+++ b/internal/service/firewall/nat_port_forward_schema_test.go
@@ -97,7 +97,7 @@ func TestConvertNATPortForwardStructToSchema(t *testing.T) {
 	result, err := convertNATPortForwardStructToSchema(&opnfirewall.NatPortForward{
 		Disabled:   "1",
 		Sequence:   "200",
-		Interface:  api.SelectedMapList{"wan"},
+		Interface:  api.SelectedMap("wan"),
 		IPProtocol: "inet",
 		Protocol:   "tcp",
 		Source: opnfirewall.NatPortForwardLocation{

--- a/internal/service/firewall/nat_port_forward_schema_test.go
+++ b/internal/service/firewall/nat_port_forward_schema_test.go
@@ -3,7 +3,10 @@ package firewall
 import (
 	"testing"
 
+	"github.com/browningluke/opnsense-go/pkg/api"
 	opnfirewall "github.com/browningluke/opnsense-go/pkg/firewall"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/require"
 )
@@ -12,7 +15,7 @@ func TestConvertNATPortForwardSchemaToStruct(t *testing.T) {
 	data := &natPortForwardResourceModel{
 		Enabled:    types.BoolValue(true),
 		Sequence:   types.Int64Value(100),
-		Interface:  types.StringValue("wan"),
+		Interface:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("wan")}),
 		IPProtocol: types.StringValue("inet"),
 		Protocol:   types.StringValue("tcp"),
 		Source: &firewallLocation{
@@ -57,9 +60,12 @@ func TestConvertNATPortForwardSchemaToStruct(t *testing.T) {
 
 func TestConvertNATPortForwardSchemaToStructWithMultipleInterfaces(t *testing.T) {
 	data := &natPortForwardResourceModel{
-		Enabled:    types.BoolValue(true),
-		Sequence:   types.Int64Value(100),
-		Interface:  types.StringValue("wan, openvpn"),
+		Enabled:  types.BoolValue(true),
+		Sequence: types.Int64Value(100),
+		Interface: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("wan"),
+			types.StringValue("openvpn"),
+		}),
 		IPProtocol: types.StringValue("inet"),
 		Protocol:   types.StringValue("tcp"),
 		Source: &firewallLocation{
@@ -84,14 +90,14 @@ func TestConvertNATPortForwardSchemaToStructWithMultipleInterfaces(t *testing.T)
 	result, err := convertNATPortForwardSchemaToStruct(data)
 
 	require.NoError(t, err)
-	require.Equal(t, "wan,openvpn", result.Interface.String())
+	require.Equal(t, "openvpn,wan", result.Interface.String())
 }
 
 func TestConvertNATPortForwardStructToSchema(t *testing.T) {
 	result, err := convertNATPortForwardStructToSchema(&opnfirewall.NatPortForward{
 		Disabled:   "1",
 		Sequence:   "200",
-		Interface:  "wan",
+		Interface:  api.SelectedMapList{"wan"},
 		IPProtocol: "inet",
 		Protocol:   "tcp",
 		Source: opnfirewall.NatPortForwardLocation{
@@ -114,7 +120,7 @@ func TestConvertNATPortForwardStructToSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, result.Enabled.ValueBool())
 	require.Equal(t, int64(200), result.Sequence.ValueInt64())
-	require.Equal(t, "wan", result.Interface.ValueString())
+	require.ElementsMatch(t, []string{"wan"}, tools.SetToStringSlice(result.Interface))
 	require.Equal(t, "inet", result.IPProtocol.ValueString())
 	require.Equal(t, "tcp", result.Protocol.ValueString())
 	require.Equal(t, "any", result.Source.Net.ValueString())
@@ -128,4 +134,10 @@ func TestConvertNATPortForwardStructToSchema(t *testing.T) {
 	require.False(t, result.Log.ValueBool())
 	require.Equal(t, "default", result.NatReflection.ValueString())
 	require.Equal(t, "Updated WAN HTTPS", result.Description.ValueString())
+}
+
+func TestNatPortForwardInterfaceStringToSet(t *testing.T) {
+	result := natPortForwardInterfaceStringToSet("wan, openvpn,,lan")
+
+	require.ElementsMatch(t, []string{"wan", "openvpn", "lan"}, tools.SetToStringSlice(result))
 }

--- a/internal/service/interfaces/overview_schema.go
+++ b/internal/service/interfaces/overview_schema.go
@@ -30,7 +30,7 @@ type overviewInterfaceModel struct {
 	VLANTag     types.String `tfsdk:"vlan_tag"`
 	LaggProto   types.String `tfsdk:"lagg_proto"`
 	LaggHash    types.String `tfsdk:"lagg_hash"`
-	LaggOptions types.String `tfsdk:"lagg_options"`
+	LaggOptions types.Object `tfsdk:"lagg_options"`
 
 	Flags          types.Set `tfsdk:"flags"`
 	Capabilities   types.Set `tfsdk:"capabilities"`
@@ -78,6 +78,11 @@ type overviewVLANModel struct {
 	Parent types.String `tfsdk:"parent"`
 }
 
+type overviewLaggOptionsModel struct {
+	Flags       types.Set    `tfsdk:"flags"`
+	FlowIDShift types.String `tfsdk:"flowid_shift"`
+}
+
 var overviewIPv4AttrTypes = map[string]attr.Type{
 	"ipaddr":      types.StringType,
 	"vhid":        types.StringType,
@@ -105,6 +110,11 @@ var overviewVLANAttrTypes = map[string]attr.Type{
 	"parent": types.StringType,
 }
 
+var overviewLaggOptionsAttrTypes = map[string]attr.Type{
+	"flags":        types.SetType{ElemType: types.StringType},
+	"flowid_shift": types.StringType,
+}
+
 var overviewInterfaceAttrTypes = map[string]attr.Type{
 	"identifier":         types.StringType,
 	"description":        types.StringType,
@@ -123,7 +133,7 @@ var overviewInterfaceAttrTypes = map[string]attr.Type{
 	"vlan_tag":           types.StringType,
 	"lagg_proto":         types.StringType,
 	"lagg_hash":          types.StringType,
-	"lagg_options":       types.StringType,
+	"lagg_options":       types.ObjectType{AttrTypes: overviewLaggOptionsAttrTypes},
 	"flags":              types.SetType{ElemType: types.StringType},
 	"capabilities":       types.SetType{ElemType: types.StringType},
 	"options":            types.SetType{ElemType: types.StringType},
@@ -276,9 +286,20 @@ func overviewInterfaceDataSourceSchema() schema.Schema {
 				MarkdownDescription: "LAGG hash configuration.",
 				Computed:            true,
 			},
-			"lagg_options": schema.StringAttribute{
+			"lagg_options": schema.SingleNestedAttribute{
 				MarkdownDescription: "LAGG options.",
 				Computed:            true,
+				Attributes: map[string]schema.Attribute{
+					"flags": schema.SetAttribute{
+						MarkdownDescription: "LAGG option flags.",
+						Computed:            true,
+						ElementType:         types.StringType,
+					},
+					"flowid_shift": schema.StringAttribute{
+						MarkdownDescription: "LAGG flow ID shift.",
+						Computed:            true,
+					},
+				},
 			},
 			"flags": schema.SetAttribute{
 				MarkdownDescription: "Interface flags.",
@@ -399,7 +420,6 @@ func convertOverviewInterfaceStructToSchema(d *interfaces.InterfaceInfo) (*overv
 		VLANTag:           types.StringValue(d.VLANTag),
 		LaggProto:         types.StringValue(d.LaggProto),
 		LaggHash:          types.StringValue(d.LaggHash),
-		LaggOptions:       types.StringValue(d.LaggOptions),
 		Flags:             tools.StringSliceToSet(d.Flags),
 		Capabilities:      tools.StringSliceToSet(d.Capabilities),
 		Options:           tools.StringSliceToSet(d.Options),
@@ -460,6 +480,15 @@ func convertOverviewInterfaceStructToSchema(d *interfaces.InterfaceInfo) (*overv
 			Proto:  types.StringValue(d.VLAN.Proto),
 			PCP:    types.StringValue(d.VLAN.PCP),
 			Parent: types.StringValue(d.VLAN.Parent),
+		},
+	)
+
+	model.LaggOptions, _ = types.ObjectValueFrom(
+		context.Background(),
+		overviewLaggOptionsAttrTypes,
+		overviewLaggOptionsModel{
+			Flags:       tools.StringSliceToSet(d.LaggOptions.Flags),
+			FlowIDShift: types.StringValue(d.LaggOptions.FlowIDShift),
 		},
 	)
 


### PR DESCRIPTION
## Description
Support multi-interface destination NAT port-forward rules.

The OPNsense API supports selecting multiple ingress interfaces for destination NAT port forwards. With the matching `opnsense-go` change, the provider can round-trip multi-interface rules by modeling `interface` as a Terraform set, for example:

```hcl
interface = ["openvpn", "wan"]
```

Existing single-interface configurations migrate from the previous string value to a one-element set:

```hcl
interface = ["wan"]
```

This PR is intentionally draft until the supporting `opnsense-go` change is merged and released. It currently expects `NatPortForward.Interface` to use `api.SelectedMapList`, as proposed in browningluke/opnsense-go#59.

## Related Issues
Depends on browningluke/opnsense-go#59.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Breaking Changes (if applicable)
- **What breaks**: `opnsense_firewall_nat_port_forward.interface` changes from a string to a set of strings.
- **Migration path**: Schema version 2 migrates existing state from the previous string value into a one-element set. Users should update configuration from `interface = "wan"` to `interface = ["wan"]`.
- **v0 exception rationale** (if no schema migration): N/A. A state upgrader is included.

## Schema Changes (if applicable)
- [x] Schema `Version` incremented
- [x] `UpgradeState` function implemented
- [ ] Or: v0 exception applies (explain why below)

**Explanation**:

The `interface` attribute is now a set of strings so Terraform can represent multi-interface NAT port-forward rules directly. The conversion layer sorts the set before sending it to OPNsense for deterministic API payloads.

## Testing
Describe how you tested your changes:
- [x] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

Tested against the local patched `opnsense-go` checkout using a temporary `go.work`:

```console
go test ./...
```

Also live-tested the underlying OPNsense API by creating a temporary disabled destination NAT rule with both `openvpn` and `wan` selected, reading it back, and deleting it.

## Examples
- [ ] Examples added/updated in `examples/` directory
- [x] N/A - No user-facing examples changed

## Environment
- **OPNsense version tested**: Live-tested against my OPNsense instance at `https://router.home`
- **Terraform version**: Not used for the live API test

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation has been generated (`make docs`)
- [x] Code has been formatted (`make fmt`)
- [ ] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [x] Tests pass locally with the dependent `opnsense-go` branch
