### PR TITLE
kea_dhcpv6 - Fix acceptance tests failing on clean OPNsense VM

### DIFF
--- a/.github/workflows/terraform-test-reusable.yml
+++ b/.github/workflows/terraform-test-reusable.yml
@@ -15,6 +15,7 @@ env:
   OPNSENSE_SSH_PORT: 8022
   OPNSENSE_WEB_PORT: 8443
   TERRAFORM_PLUGIN_URI: "registry.terraform.io/browningluke/opnsense"
+  OPNSENSE_KEA_DHCPV6_IFACE: wan
 
 jobs:
   build:

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1,8 +1,14 @@
 package acctest
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"testing"
 
@@ -46,4 +52,92 @@ func AccPreCheck(t *testing.T) {
 	if v := os.Getenv("OPNSENSE_API_SECRET"); v == "" {
 		t.Fatal("OPNSENSE_API_SECRET must be set for acceptance tests")
 	}
+}
+
+// DomainOverridePreCheck skips the test unless OPNSENSE_TEST_DOMAIN_OVERRIDE=1.
+// The addDomainOverride endpoint was removed in OPNsense 25+ and returns an empty
+// body on newer versions. Set this variable only on OPNsense 24.x or earlier.
+func DomainOverridePreCheck(t *testing.T) {
+	t.Helper()
+	AccPreCheck(t)
+	if os.Getenv("OPNSENSE_TEST_DOMAIN_OVERRIDE") != "1" {
+		t.Skip("OPNSENSE_TEST_DOMAIN_OVERRIDE=1 required: addDomainOverride endpoint removed in OPNsense 25+")
+	}
+}
+
+// KeaDhcpv6PreCheck skips the test unless OPNSENSE_KEA_DHCPV6_IFACE is set to a
+// valid interface name (e.g. "wan"). When set, it configures that interface in the
+// Kea DHCPv6 general settings before the test runs and resets it to empty on cleanup.
+func KeaDhcpv6PreCheck(t *testing.T) {
+	t.Helper()
+	AccPreCheck(t)
+
+	iface := os.Getenv("OPNSENSE_KEA_DHCPV6_IFACE")
+	if iface == "" {
+		t.Skip("OPNSENSE_KEA_DHCPV6_IFACE must be set to a valid interface (e.g. 'wan') for Kea DHCPv6 tests")
+	}
+
+	uri := os.Getenv("OPNSENSE_URI")
+	key := os.Getenv("OPNSENSE_API_KEY")
+	secret := os.Getenv("OPNSENSE_API_SECRET")
+
+	if err := setKeaDhcpv6Interface(t, uri, key, secret, iface); err != nil {
+		t.Fatalf("KeaDhcpv6PreCheck: failed to configure interface %q: %s", iface, err)
+	}
+
+	t.Cleanup(func() {
+		if err := setKeaDhcpv6Interface(t, uri, key, secret, ""); err != nil {
+			t.Logf("KeaDhcpv6PreCheck cleanup: failed to reset interface: %s", err)
+		}
+	})
+}
+
+func setKeaDhcpv6Interface(t *testing.T, uri, key, secret, iface string) error {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"dhcpv6": map[string]any{
+			"general": map[string]any{
+				"interfaces": iface,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, uri+"/api/kea/dhcpv6/set", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(key+":"+secret)))
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: os.Getenv("OPNSENSE_ALLOW_INSECURE") == "true",
+		},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Result string `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if result.Result != "saved" {
+		return fmt.Errorf("unexpected result: %q", result.Result)
+	}
+	return nil
 }

--- a/internal/service/kea/dhcpv6_pd_pool_resource_test.go
+++ b/internal/service/kea/dhcpv6_pd_pool_resource_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccKeaDhcpv6PdPoolResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		PreCheck:                 func() { acctest.KeaDhcpv6PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing

--- a/internal/service/kea/dhcpv6_reservation_resource_test.go
+++ b/internal/service/kea/dhcpv6_reservation_resource_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccKeaDhcpv6ReservationResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		PreCheck:                 func() { acctest.KeaDhcpv6PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing

--- a/internal/service/kea/dhcpv6_subnet_resource_test.go
+++ b/internal/service/kea/dhcpv6_subnet_resource_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccKeaDhcpv6SubnetResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		PreCheck:                 func() { acctest.KeaDhcpv6PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing


### PR DESCRIPTION
## Description
Fix Kea DHCPv6 acceptance tests failing on a clean OPNsense VM. The three DHCPv6 acceptance tests (subnet, reservation, PD pool) require at least one interface configured in Services → DHCPv6 → General Settings before any resource can be created. A clean install has no interface set, causing all three tests to fail with "subnet6.interface: Interface not configured in general settings". This PR adds a dedicated pre-check helper that configures the interface before the test suite runs and resets it on cleanup.

## Related Issues
Fixes #79

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
- **What breaks**: N/A
- **Migration path**: N/A
- **v0 exception rationale** (if no schema migration): N/A

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: v0 exception applies (explain why below)

**Explanation**: No schema changes. This PR touches only test infrastructure (`acctest.go` and `*_resource_test.go` files). No resource schema, provider schema, or user-facing behaviour is modified.

## Testing
Describe how you tested your changes:
- [ ] Unit tests added/updated (optional, but encouraged)
- [x] Acceptance tests added/updated (mandatory)

All three previously failing Kea DHCPv6 acceptance tests now pass on OPNsense 26.1 using a single-NIC wan-only VM with `OPNSENSE_KEA_DHCPV6_IFACE=wan`:

| Test | Before | After |
|---|---|---|
| TestAccKeaDhcpv6SubnetResource | FAIL | PASS |
| TestAccKeaDhcpv6ReservationResource | FAIL | PASS |
| TestAccKeaDhcpv6PdPoolResource | FAIL | PASS |
| TestAccKeaDhcpv4PeerResource | PASS | PASS |
| TestAccKeaDhcpv4ReservationResource | PASS | PASS |
| TestAccKeaDhcpv4SubnetResource | PASS | PASS |
| TestAccKeaDhcpv6PeerResource | PASS | PASS |

The new `KeaDhcpv6PreCheck(t)` helper in `internal/acctest/acctest.go`:
1. Skips the test unless `OPNSENSE_KEA_DHCPV6_IFACE` is set.
2. On entry, POSTs to `/api/kea/dhcpv6/set` to register the interface in general settings.
3. Registers a `t.Cleanup` callback that POSTs again with an empty interface to restore the VM to its clean state after the test run.

The three test files (`dhcpv6_subnet_resource_test.go`, `dhcpv6_pd_pool_resource_test.go`, `dhcpv6_reservation_resource_test.go`) each have a one-line swap from `AccPreCheck` to `KeaDhcpv6PreCheck`.

## Examples
- [ ] Examples added/updated in `examples/` directory
- [x] N/A - No user-facing changes

## Environment
- **OPNsense version tested**: 26.1 (single-NIC wan-only VM)
- **Terraform version**: OpenTofu v1.11.5 (provider framework v6)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`)
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [x] Tests pass locally & in test workflow
