### PR TITLE
feat(firewall): support floating filter rules with empty interface set

### DIFF
--- a/docs/data-sources/firewall_filter.md
+++ b/docs/data-sources/firewall_filter.md
@@ -76,7 +76,7 @@ Read-Only:
 
 Read-Only:
 
-- `interface` (Set of String) The interfaces the filter rule is applied on.
+- `interface` (Set of String) The interfaces the filter rule is applied on. An empty set indicates a floating rule that applies to all interfaces.
 - `invert` (Boolean) Whether all but selected interfaces are used.
 
 

--- a/docs/resources/firewall_filter.md
+++ b/docs/resources/firewall_filter.md
@@ -30,7 +30,26 @@ resource "opnsense_firewall_filter" "minimal" {
   }
 }
 
-# Example 2: Typical use case: Allow HTTPS traffic from specific source to web server
+# Example 2: Floating firewall rule (applies to all interfaces)
+resource "opnsense_firewall_filter" "floating_icmpv6" {
+  enabled     = true
+  sequence    = 1
+  description = "Allow ICMPv6 on all interfaces"
+
+  interface = {
+    interface = []
+  }
+
+  filter = {
+    quick       = true
+    action      = "pass"
+    direction   = "in"
+    protocol    = "IPV6-ICMP"
+    ip_protocol = "inet6"
+  }
+}
+
+# Example 4: Typical use case: Allow HTTPS traffic from specific source to web server
 resource "opnsense_firewall_filter" "allow_https" {
   enabled     = true
   sequence    = 100
@@ -67,7 +86,7 @@ resource "opnsense_firewall_filter" "allow_https" {
   }
 }
 
-# Example 3: Comprehensive example with all attributes explicitly configured
+# Example 5: Comprehensive example with all attributes explicitly configured
 resource "opnsense_firewall_filter" "comprehensive" {
   enabled        = true
   sequence       = 200
@@ -250,12 +269,9 @@ Optional:
 <a id="nestedatt--interface"></a>
 ### Nested Schema for `interface`
 
-Required:
-
-- `interface` (Set of String) The interfaces to apply the filter rule on.
-
 Optional:
 
+- `interface` (Set of String) The interfaces to apply the filter rule on. Leave empty (`[]`) for a floating rule that applies to all interfaces.
 - `invert` (Boolean) Whether to use all but selected interfaces. Defaults to `false`.
 
 

--- a/examples/resources/opnsense_firewall_filter/resource.tf
+++ b/examples/resources/opnsense_firewall_filter/resource.tf
@@ -16,7 +16,26 @@ resource "opnsense_firewall_filter" "minimal" {
   }
 }
 
-# Example 2: Typical use case: Allow HTTPS traffic from specific source to web server
+# Example 2: Floating firewall rule (applies to all interfaces)
+resource "opnsense_firewall_filter" "floating_icmpv6" {
+  enabled     = true
+  sequence    = 1
+  description = "Allow ICMPv6 on all interfaces"
+
+  interface = {
+    interface = []
+  }
+
+  filter = {
+    quick       = true
+    action      = "pass"
+    direction   = "in"
+    protocol    = "IPV6-ICMP"
+    ip_protocol = "inet6"
+  }
+}
+
+# Example 4: Typical use case: Allow HTTPS traffic from specific source to web server
 resource "opnsense_firewall_filter" "allow_https" {
   enabled     = true
   sequence    = 100
@@ -53,7 +72,7 @@ resource "opnsense_firewall_filter" "allow_https" {
   }
 }
 
-# Example 3: Comprehensive example with all attributes explicitly configured
+# Example 5: Comprehensive example with all attributes explicitly configured
 resource "opnsense_firewall_filter" "comprehensive" {
   enabled        = true
   sequence       = 200

--- a/internal/service/firewall/filter_resource_test.go
+++ b/internal/service/firewall/filter_resource_test.go
@@ -252,6 +252,44 @@ func TestAccFirewallFilterResource_Comprehensive(t *testing.T) {
 	})
 }
 
+func TestAccFirewallFilterResource_Floating(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create floating rule (empty interface list)
+			{
+				Config: testAccFirewallFilterResourceConfigFloating("pass", "in", "any"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "interface.interface.#", "0"),
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "filter.action", "pass"),
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "filter.direction", "in"),
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "filter.protocol", "any"),
+					resource.TestCheckResourceAttrSet("opnsense_firewall_filter.test", "id"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "opnsense_firewall_filter.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update floating rule
+			{
+				Config: testAccFirewallFilterResourceConfigFloating("block", "out", "TCP"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "interface.interface.#", "0"),
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "filter.action", "block"),
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "filter.direction", "out"),
+					resource.TestCheckResourceAttr("opnsense_firewall_filter.test", "filter.protocol", "TCP"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func TestAccFirewallFilterResource_DirectionAny(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccPreCheck(t) },
@@ -293,7 +331,24 @@ func TestAccFirewallFilterResource_DirectionAny(t *testing.T) {
 	})
 }
 
+
 // Helper functions to generate test configurations
+
+func testAccFirewallFilterResourceConfigFloating(action, direction, protocol string) string {
+	return fmt.Sprintf(`
+resource "opnsense_firewall_filter" "test" {
+  interface = {
+    interface = []
+  }
+
+  filter = {
+    action    = %[1]q
+    direction = %[2]q
+    protocol  = %[3]q
+  }
+}
+`, action, direction, protocol)
+}
 
 func testAccFirewallFilterResourceConfigMinimal(iface, action, direction, protocol string) string {
 	return fmt.Sprintf(`

--- a/internal/service/firewall/filter_schema.go
+++ b/internal/service/firewall/filter_schema.go
@@ -197,12 +197,11 @@ func filterResourceSchema() schema.Schema {
 						Default:             booldefault.StaticBool(false),
 					},
 					"interface": schema.SetAttribute{
-						MarkdownDescription: "The interfaces to apply the filter rule on.",
-						Required:            true,
+						MarkdownDescription: "The interfaces to apply the filter rule on. Leave empty (`[]`) for a floating rule that applies to all interfaces.",
+						Optional:            true,
+						Computed:            true,
 						ElementType:         types.StringType,
-						Validators: []validator.Set{
-							setvalidator.SizeAtLeast(1),
-						},
+						Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 					},
 				},
 			},
@@ -984,7 +983,7 @@ func filterDataSourceSchema() dschema.Schema {
 						Computed:            true,
 					},
 					"interface": dschema.SetAttribute{
-						MarkdownDescription: "The interfaces the filter rule is applied on.",
+						MarkdownDescription: "The interfaces the filter rule is applied on. An empty set indicates a floating rule that applies to all interfaces.",
 						Computed:            true,
 						ElementType:         types.StringType,
 					},


### PR DESCRIPTION
## Description
Allows `interface.interface` to be empty (`[]`), enabling floating firewall rules that apply to all interfaces. OPNsense represents floating rules by storing an empty interface field — previously the provider rejected this with a `SizeAtLeast(1)` validator.

## Related Issues
Closes #93 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
N/A — this is a non-breaking relaxation of a validation constraint. Existing configs with one or more interfaces continue to work unchanged.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: v0 exception applies (explain why below)

**Explanation**: Only a validator was removed (`SizeAtLeast(1)` on `interface.interface`). The stored data format (a set of strings) is identical — the field could already be empty in state retrieved from the API. No state migration is required.

## Testing
- [ ] Unit tests added/updated (optional, but encouraged)
- [x] Acceptance tests added/updated (mandatory)

Added `TestAccFirewallFilterResource_Floating` which creates, imports, updates, and deletes a floating rule (empty interface set). All filter acceptance tests pass against a live OPNsense VM.

## Examples
- [x] Examples added/updated in `examples/` directory

Added a floating ICMPv6 example to `examples/resources/opnsense_firewall_filter/resource.tf`.

## Environment
- **OPNsense version tested**: 25.1
- **Terraform version**: 1.x

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`)
- [x] Code has been formatted (`make fmt`)
- [ ] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [x] Tests pass locally & in test workflow