### PR TITLE
fix(provider): assign min_backoff config to minBackoff

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -221,7 +221,7 @@ func (p *opnsenseProvider) Configure(ctx context.Context, req provider.Configure
 		minBackoff = 0
 	}
 	if !data.MinBackoff.IsNull() {
-		maxBackoff = data.MinBackoff.ValueInt64()
+		minBackoff = data.MinBackoff.ValueInt64()
 	}
 
 	retriesStr := os.Getenv("OPNSENSE_RETRIES")


### PR DESCRIPTION
## Description
The provider config block reading `data.MinBackoff` assigned to the wrong local variable: `maxBackoff = data.MinBackoff.ValueInt64()`. Setting `min_backoff` in HCL silently clobbered `max_backoff` while leaving the actual `minBackoff` unchanged from its env/default value.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
N/A

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: no schema change

**Explanation**: pure provider-Configure logic fix; resource schemas untouched.

## Testing
Describe how you tested your changes:
- [ ] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

This is a one-line typo fix in a non-test code path; existing tests cover the surrounding logic. The bug only manifested when a user set `min_backoff` in HCL — there were no tests asserting the assignment direction.

## Examples
- [x] N/A - No user-facing changes

## Environment
- **OPNsense version tested**: N/A (no API interaction)
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`) — N/A, no schema/doc change
- [x] Code has been formatted (`make fmt`)
- [ ] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go) — N/A
- [ ] Tests pass locally & in test workflow