### PR TITLE
feat(dnsmasq_host): expose set_tag as 'tag' attribute

### DIFF
--- a/docs/data-sources/dnsmasq_host.md
+++ b/docs/data-sources/dnsmasq_host.md
@@ -32,3 +32,4 @@ Configure hosts override for dnsmasq.
 - `hardware_addresses` (Set of String) Hardware addresses of the host.
 - `is_ignored` (Boolean) Whether DHCP packet is ignored for this host.
 - `is_local_domain` (Boolean) Whether this is a local domain.
+- `tag` (String) UUID of the dnsmasq tag associated with this host.

--- a/docs/resources/dnsmasq_host.md
+++ b/docs/resources/dnsmasq_host.md
@@ -55,6 +55,7 @@ resource "opnsense_dnsmasq_host" "test_xl" {
 - `hardware_addresses` (Set of String) Hardware addresses of the host.
 - `is_ignored` (Boolean) Whether DHCP packet is ignored for this host.
 - `is_local_domain` (Boolean) Whether this is a local domain.
+- `tag` (String) UUID of the dnsmasq tag to associate with this host. Defaults to `""`.
 
 ### Read-Only
 

--- a/internal/service/dnsmasq/host_schema.go
+++ b/internal/service/dnsmasq/host_schema.go
@@ -1,6 +1,7 @@
 package dnsmasq
 
 import (
+	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/dnsmasq"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -22,6 +23,7 @@ type hostResourceModel struct {
 	CnameRecords    types.Set    `tfsdk:"cname_records"`
 	ClientID        types.String `tfsdk:"client_id"`
 	HarwareAdresses types.Set    `tfsdk:"hardware_addresses"`
+	Tag             types.String `tfsdk:"tag"`
 	IsIgnored       types.Bool   `tfsdk:"is_ignored"`
 	Description     types.String `tfsdk:"description"`
 	Comment         types.String `tfsdk:"comment"`
@@ -80,6 +82,12 @@ func hostResourceSchema() schema.Schema {
 				Optional:            true,
 				Computed:            true,
 				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"tag": schema.StringAttribute{
+				MarkdownDescription: "UUID of the dnsmasq tag to associate with this host. Defaults to `\"\"`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
 			},
 			"is_ignored": schema.BoolAttribute{
 				MarkdownDescription: "Whether DHCP packet is ignored for this host.",
@@ -150,6 +158,10 @@ func hostDataSourceSchema() dschema.Schema {
 				ElementType:         types.StringType,
 				Computed:            true,
 			},
+			"tag": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the dnsmasq tag associated with this host.",
+				Computed:            true,
+			},
 			"is_ignored": dschema.BoolAttribute{
 				MarkdownDescription: "Whether DHCP packet is ignored for this host.",
 				Computed:            true,
@@ -181,6 +193,7 @@ func convertHostSchemaToStruct(d *hostResourceModel) (*dnsmasq.Host, error) {
 		CnameRecords:      tools.SetToStringSlice(d.CnameRecords),
 		ClientId:          d.ClientID.ValueString(),
 		HardwareAddresses: tools.SetToStringSlice(d.HarwareAdresses),
+		Tag:               api.SelectedMap(d.Tag.ValueString()),
 		IsIgnored:         tools.BoolToString(d.IsIgnored.ValueBool()),
 		Description:       d.Description.ValueString(),
 		Comments:          d.Comment.ValueString(),
@@ -197,6 +210,7 @@ func convertHostStructToSchema(d *dnsmasq.Host) (*hostResourceModel, error) {
 		CnameRecords:    tools.StringSliceToSet(d.CnameRecords),
 		ClientID:        types.StringValue(d.ClientId),
 		HarwareAdresses: tools.StringSliceToSet(d.HardwareAddresses),
+		Tag:             types.StringValue(d.Tag.String()),
 		IsIgnored:       types.BoolValue(tools.StringToBool(d.IsIgnored)),
 		Description:     types.StringValue(d.Description),
 		Comment:         types.StringValue(d.Comments),


### PR DESCRIPTION
## Description
`opnsense-go`'s `dnsmasq.Host` struct exposes a `Tag` (`set_tag`) SelectedMap field, but the provider's `hostResourceModel` / schema / convert functions ignored it. As a result, any tag assigned to a dnsmasq host via the OPNsense UI was wiped to empty on every Update through Terraform.

This adds an `Optional+Computed` `tag` string attribute on the resource and a `Computed` `tag` attribute on the data source. The value is the UUID of a dnsmasq tag.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
- **What breaks**: none — the field is new and `Optional+Computed` with a default of `""`, matching the convention used by other string fields on this resource.
- **Migration path**: N/A
- **v0 exception rationale**: matches the established pattern for adding new `Optional+Computed+Default("")` attributes (e.g. `path_expression` on the firewall alias).

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: v0 exception applies

**Explanation**: Adding a new `Optional+Computed+Default("")` attribute is not a state-breaking change. Refresh fills the field from the upstream `set_tag` value; HCL omits the field → default `""` → no diff if the upstream is unset. This matches the established convention in this repo (see the recent `path_expression` addition on the firewall alias resource).

## Testing
Describe how you tested your changes:
- [ ] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

Existing dnsmasq host acceptance tests still apply unchanged. A dedicated acceptance test that round-trips the `tag` field requires a tag UUID, which depends on a yet-to-exist `opnsense_dnsmasq_tag` resource — out of scope here.

## Examples
- [x] N/A - example code already shows other Optional fields; no new example needed.

## Environment
- **OPNsense version tested**: not yet against live VM (single-attribute plumbing)
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`)
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go) — `Tag` already lives in `opnsense-go` v0.20.0
- [ ] Tests pass locally & in test workflow