### PR TITLE
fix(wireguard_server): enforce gateway-required-when-disable_routes invariant

### DIFF
--- a/internal/service/wireguard/server_schema.go
+++ b/internal/service/wireguard/server_schema.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/browningluke/opnsense-go/pkg/wireguard"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/browningluke/terraform-provider-opnsense/internal/validators"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -106,9 +106,7 @@ func serverResourceSchema() schema.Schema {
 				Computed:            true,
 				Default:             stringdefault.StaticString(""),
 				Validators: []validator.String{
-					stringvalidator.AlsoRequires(path.Expressions{
-						path.MatchRoot("disable_routes"),
-					}...),
+					validators.RequiredWhenBool(path.MatchRoot("disable_routes"), true),
 				},
 			},
 			"instance": schema.StringAttribute{

--- a/internal/validators/required_when_bool.go
+++ b/internal/validators/required_when_bool.go
@@ -1,0 +1,70 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type requiredWhenBoolValidator struct {
+	expression path.Expression
+	value      bool
+}
+
+func (v requiredWhenBoolValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("must be set to a non-empty value when %s is %v", v.expression, v.value)
+}
+
+func (v requiredWhenBoolValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v requiredWhenBoolValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	// Pass: this attribute already has a non-empty value.
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() && req.ConfigValue.ValueString() != "" {
+		return
+	}
+
+	matchedPaths, diags := req.Config.PathMatches(ctx, v.expression)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for _, p := range matchedPaths {
+		var other types.Bool
+		resp.Diagnostics.Append(req.Config.GetAttribute(ctx, p, &other)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Defer judgement until the other attribute is known.
+		if other.IsUnknown() {
+			return
+		}
+
+		// If the other attribute is unset, the schema default fires at plan
+		// time; we treat "unset" as "not the trigger value" and let plan
+		// re-validate when the value is concrete.
+		if other.IsNull() {
+			continue
+		}
+
+		if other.ValueBool() == v.value {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Missing required attribute",
+				fmt.Sprintf("Attribute %q must be set to a non-empty value when %q is %v.", req.Path, p, v.value),
+			)
+		}
+	}
+}
+
+// RequiredWhenBool returns a validator that errors if the attribute is
+// null/empty while the bool attribute at the given path equals value.
+func RequiredWhenBool(expression path.Expression, value bool) validator.String {
+	return requiredWhenBoolValidator{expression: expression, value: value}
+}


### PR DESCRIPTION
## Description
The `gateway` attribute on `opnsense_wireguard_server` is documented as "Must be set when `disable_routes` is `true`", but the actual validator was:

```go
stringvalidator.AlsoRequires(path.Expressions{
    path.MatchRoot("disable_routes"),
}...),
```

`AlsoRequires` only checks whether the referenced path is *configured*. Since `disable_routes` is `Optional+Computed` with `Default(false)`, it is always considered configured at validation time, so the validator never fired and the documented constraint was never enforced. Users could set `disable_routes = true` without specifying a `gateway` and the bad config would only surface at apply time (or worse, silently).

## Changes

- New `internal/validators/required_when_bool.go` providing `RequiredWhenBool(path, value)` — errors when this attribute is null/empty and the referenced bool attribute equals the given trigger value.
- `internal/service/wireguard/server_schema.go`: replace the no-op `AlsoRequires` with `validators.RequiredWhenBool(path.MatchRoot("disable_routes"), true)`.
- Drop the now-unused `stringvalidator` import.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
- **What breaks**: configurations that set `disable_routes = true` without setting `gateway` will now be rejected at plan time. Such configurations were already broken at runtime — the API has no useful behaviour without a gateway when routes are disabled — but the provider was permitting them.
- **Migration path**: set `gateway = "<ip>"` on any wireguard_server where `disable_routes = true`.
- **v0 exception rationale**: tightens a never-enforced validator; no state shape change.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: v0 exception applies

**Explanation**: No state schema change; only validator behaviour.

## Testing
Describe how you tested your changes:
- [ ] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

Build / vet clean. The new validator follows the same pattern as the existing `internal/validators/uuid.go` / `ip_cidr.go`. Acceptance coverage for the failure mode would need a deliberate-bad-config plan test — happy to add if you'd like before merge.

## Examples
- [x] N/A - No user-facing schema change.

## Environment
- **OPNsense version tested**: N/A (config-time validation only)
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`) — no diff
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go) — N/A, provider-only
- [ ] Tests pass locally & in test workflow