### PR TITLE
fix(nat_one_to_one): enforce description length and character set

### DIFF
--- a/internal/service/firewall/nat_one_to_one_schema.go
+++ b/internal/service/firewall/nat_one_to_one_schema.go
@@ -160,6 +160,13 @@ func natOneToOneResourceSchema() schema.Schema {
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Optional description here for your reference (not parsed). Must be between 0 and 255 characters. Must be a character in set `[a-zA-Z0-9 .]`.",
 				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-zA-Z0-9 .]*$`),
+						"must only contain only alphanumeric characters, spaces or `.`",
+					),
+					stringvalidator.LengthAtMost(255),
+				},
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
## Description
The `description` attribute on `opnsense_firewall_nat_one_to_one` advertises in its markdown that it must be 0-255 characters and `[a-zA-Z0-9 .]`, but no `Validators` were attached. Misformed descriptions only surfaced at apply time as opaque API rejections. Sibling NAT resources (`nat`, `nat_port_forward`) already attach matching `RegexMatches` + length validators.

Add the same regex and a `LengthAtMost(255)` validator, honouring the existing markdown's 0-character lower bound (the attribute is `Optional` with no default — an explicit empty string is legal).

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
- **What breaks**: configurations whose `description` contained disallowed characters or exceeded 255 characters will now be rejected at plan time. Those configurations were already rejected at apply time by the API, so this surfaces the problem earlier.
- **Migration path**: trim/sanitise the description.
- **v0 exception rationale**: tightens an already-documented constraint that was never enforced; no state shape change.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: v0 exception applies

**Explanation**: Validators-only change. No state schema change.

## Testing
Describe how you tested your changes:
- [ ] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

Build / vet clean. `go generate ./...` regenerates docs with no diff (markdown was already documenting these constraints). Existing acceptance coverage still applies.

## Examples
- [x] N/A - No user-facing schema change.

## Environment
- **OPNsense version tested**: N/A (config-time validation only)
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`) — no diff
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go) — N/A, provider-only
- [ ] Tests pass locally & in test workflow