### PR TITLE
fix(vlan): treat empty API priority as the schema default 0

### DIFF
--- a/internal/service/interfaces/vlan_schema.go
+++ b/internal/service/interfaces/vlan_schema.go
@@ -119,10 +119,15 @@ func convertVlanSchemaToStruct(d *vlanResourceModel) (*interfaces.Vlan, error) {
 }
 
 func convertVlanStructToSchema(d *interfaces.Vlan) (*vlanResourceModel, error) {
+	priority := int64(0)
+	if s := d.Priority.String(); s != "" {
+		priority = tools.StringToInt64(s)
+	}
+
 	return &vlanResourceModel{
 		Description: tools.StringOrNull(d.Description),
 		Tag:         tools.StringToInt64Null(d.Tag),
-		Priority:    tools.StringToInt64Null(d.Priority.String()),
+		Priority:    types.Int64Value(priority),
 		Parent:      types.StringValue(d.Parent.String()),
 		Device:      types.StringValue(d.Device),
 	}, nil


### PR DESCRIPTION
## Description
`vlanResourceModel.Priority` is declared `Optional+Computed` with `Default(0)`, so its state value must always be a known `Int64`. `convertVlanStructToSchema` was using `tools.StringToInt64Null`, which returns `types.Int64Null()` whenever the upstream API responds with an empty string — and OPNsense does return an empty priority on freshly-created or zero-priority VLANs. The resulting Null violates the Computed contract and surfaces as `provider produced inconsistent result` during apply.

Branch on empty and substitute the schema default (0) when the upstream returns an unparseable string.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
None — state value goes from "sometimes Null" (broken) to "always Known". Existing valid states (Priority was set non-empty) round-trip unchanged.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: no schema change

**Explanation**: Convert-function-only change. Schema shape and defaults unchanged.

## Testing
- [ ] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

Build / vet clean. Acceptance coverage exists for VLAN happy-path; the broken branch was reproducible only when OPNsense emits an empty `priority` string.

## Examples
- [x] N/A - No user-facing schema change.

## Environment
- **OPNsense version tested**: N/A (string-conversion logic only)
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`) — no diff
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go) — N/A
- [ ] Tests pass locally & in test workflow