### PR TITLE
fix(diagnostics): make device computed in interface_all list items

### DIFF
--- a/docs/data-sources/interface_all.md
+++ b/docs/data-sources/interface_all.md
@@ -36,13 +36,10 @@ output "specific_mac" {
 <a id="nestedatt--interfaces"></a>
 ### Nested Schema for `interfaces`
 
-Required:
-
-- `device` (String) Name of the interface device.
-
 Read-Only:
 
 - `capabilities` (Set of String) List of capabilities the interface supports.
+- `device` (String) Name of the interface device.
 - `flags` (Set of String) List of flags configured on the interface (equiv. to flags=xxxx in output of ifconfig).
 - `groups` (Set of String) List of groups the interface is a member of.
 - `ipv4` (Attributes List) (see [below for nested schema](#nestedatt--interfaces--ipv4))

--- a/internal/service/diagnostics/interface_all_schema.go
+++ b/internal/service/diagnostics/interface_all_schema.go
@@ -14,6 +14,15 @@ type interfaceAllDataSourceModel struct {
 }
 
 func interfaceAllDataSourceSchema() schema.Schema {
+	// The single-interface schema declares device as Required because it is
+	// the lookup key there. Inside a fully-Computed nested list, Required is
+	// not a legal mode, so override device to Computed for the list view.
+	listItemAttrs := interfaceDataSourceSchema().Attributes
+	listItemAttrs["device"] = schema.StringAttribute{
+		MarkdownDescription: "Name of the interface device.",
+		Computed:            true,
+	}
+
 	return schema.Schema{
 		MarkdownDescription: "InterfacesAll can be used to get a list of all configurations of OPNsense interfaces. Allows for custom filtering.",
 
@@ -21,7 +30,7 @@ func interfaceAllDataSourceSchema() schema.Schema {
 			"interfaces": schema.ListNestedAttribute{
 				MarkdownDescription: "A list of all interfaces present in OPNsense.",
 				NestedObject: schema.NestedAttributeObject{
-					Attributes: interfaceDataSourceSchema().Attributes,
+					Attributes: listItemAttrs,
 				},
 				Computed: true,
 			},


### PR DESCRIPTION
## Description
`interface_all_data_source_schema` embedded `interfaceDataSourceSchema().Attributes` as the nested-object attributes of its `Computed: true` list. The single-interface schema marks `device` as `Required: true` because it is the lookup key there. `Required: true` is not a legal mode for an attribute nested inside a fully-Computed list and is rejected by the Plugin Framework.

Override `device` to `Computed: true` for the list-nested view, leaving the single-interface schema alone.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
None — the data source's behaviour from the user side is unchanged; only the schema validation is fixed.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: no resource state schema change

**Explanation**: Data source, not resource — there is no Terraform state to migrate.

## Testing
- [ ] Unit tests added/updated
- [ ] Acceptance tests added/updated

Build / vet clean. `make docs` produced a small diff (the `interface_all` doc now lists `device` under Read-Only attributes alongside the other computed fields, which is the correct rendering).

## Examples
- [x] N/A

## Environment
- **OPNsense version tested**: N/A
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`)
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code released in opnsense-go — N/A
- [ ] Tests pass locally & in test workflow