### PR TITLE
fix(firewall): read back partial-create state from upstream

### DIFF
--- a/internal/service/firewall/filter_resource.go
+++ b/internal/service/firewall/filter_resource.go
@@ -108,10 +108,18 @@ func (r *filterResource) Create(ctx context.Context, req resource.CreateRequest,
 	id, err := r.client.Firewall().AddFilter(ctx, resourceStruct)
 	if err != nil {
 		if id != "" {
-			// Tag new resource with ID from OPNsense
 			data.Id = types.StringValue(id)
 
-			// Save data into Terraform state
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if resourceStruct, readErr := r.client.Firewall().GetFilter(ctx, id); readErr == nil {
+				if readModel, convErr := convertFilterStructToSchema(resourceStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
 			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		}
 

--- a/internal/service/firewall/nat_port_forward_resource.go
+++ b/internal/service/firewall/nat_port_forward_resource.go
@@ -77,10 +77,18 @@ func (r *natPortForwardResource) Create(ctx context.Context, req resource.Create
 	id, err := r.client.Firewall().AddNatPortForward(ctx, portForward)
 	if err != nil {
 		if id != "" {
-			// Tag new resource with ID from OPNsense
 			data.Id = types.StringValue(id)
 
-			// Save data into Terraform state
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if resourceStruct, readErr := r.client.Firewall().GetNatPortForward(ctx, id); readErr == nil {
+				if readModel, convErr := convertNATPortForwardStructToSchema(resourceStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
 			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 		}
 


### PR DESCRIPTION
## Description
When `AddFilter` / `AddNatPortForward` returned a UUID together with an error (resource created upstream, post-save reconfigure failed), `Create` wrote the plan-derived model directly into Terraform state. Plan data still carries Unknown/Computed placeholders and never reflects fields the API normalises (whitespace trimming, monad defaults, sorting), so the next plan would diff or fail with `provider produced inconsistent result`.

On the rescue path, try to read the resource back from the API and convert it through the existing struct-to-schema function before saving. Fall back to saving just the ID if the read-back itself fails — that still avoids orphaning the upstream resource and matches what the next refresh would produce.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
None — only the partial-failure recovery path changes. The happy path is untouched.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: no schema change

**Explanation**: Resource-handler logic only.

## Testing
- [ ] Unit tests added/updated
- [ ] Acceptance tests added/updated

Build / vet clean. Reproducing the rescue path requires upstream returning UUID + error simultaneously (reconfigure failing after add), which is not deterministic from an acceptance test; the change is behaviour-preserving on the happy path.

## Examples
- [x] N/A

## Environment
- **OPNsense version tested**: N/A (logic-only on a rare error path)
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`) — no diff
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code released in opnsense-go — N/A
- [ ] Tests pass locally & in test workflow