### PR TITLE
fix(dnsmasq_host): only id is required on the data source

### DIFF
--- a/docs/data-sources/dnsmasq_host.md
+++ b/docs/data-sources/dnsmasq_host.md
@@ -17,9 +17,7 @@ Configure hosts override for dnsmasq.
 
 ### Required
 
-- `hostname` (String) Name of the host, without the domain part.
 - `id` (String) UUID of the host.
-- `ip_addresses` (Set of String) IP addresses of the host.
 
 ### Read-Only
 
@@ -30,6 +28,8 @@ Configure hosts override for dnsmasq.
 - `description` (String) Optional description.
 - `domain` (String) Domain of the host.
 - `hardware_addresses` (Set of String) Hardware addresses of the host.
+- `hostname` (String) Name of the host, without the domain part.
+- `ip_addresses` (Set of String) IP addresses of the host.
 - `is_ignored` (Boolean) Whether DHCP packet is ignored for this host.
 - `is_local_domain` (Boolean) Whether this is a local domain.
 - `tag` (String) UUID of the dnsmasq tag associated with this host.

--- a/internal/service/dnsmasq/host_schema.go
+++ b/internal/service/dnsmasq/host_schema.go
@@ -124,7 +124,7 @@ func hostDataSourceSchema() dschema.Schema {
 		Attributes: map[string]dschema.Attribute{
 			"hostname": dschema.StringAttribute{
 				MarkdownDescription: "Name of the host, without the domain part.",
-				Required:            true,
+				Computed:            true,
 			},
 			"domain": dschema.StringAttribute{
 				MarkdownDescription: "Domain of the host.",
@@ -137,7 +137,7 @@ func hostDataSourceSchema() dschema.Schema {
 			"ip_addresses": dschema.SetAttribute{
 				MarkdownDescription: "IP addresses of the host.",
 				ElementType:         types.StringType,
-				Required:            true,
+				Computed:            true,
 			},
 			"alias_records": dschema.SetAttribute{
 				MarkdownDescription: "Alias records of the host.",


### PR DESCRIPTION
## Description
`hostDataSource.Read` looks the host up using `data.Id` and overwrites every other attribute from the upstream response. Declaring `hostname` and `ip_addresses` as `Required` on the data source schema forced users to specify dummy values that were silently ignored on the way in and then overwritten on the way out, producing drift on every plan.

Drop both fields to `Computed` so the data source's required surface matches its actual lookup key (`id`).

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
Existing data-source configs that set `hostname` / `ip_addresses` to valid (or any) values still work — those attributes are now Computed and the values from HCL are ignored exactly as they were before. The drift previously triggered will go away.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: data source, no Terraform state to migrate

## Testing
- [ ] Unit tests added/updated
- [ ] Acceptance tests added/updated

Build / vet clean. `make docs` updated `docs/data-sources/dnsmasq_host.md` to move `hostname` and `ip_addresses` from Required to Read-Only.

## Examples
- [x] N/A

## Environment
- **OPNsense version tested**: N/A
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`)
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code released in opnsense-go — N/A
- [ ] Tests pass locally & in test workflow