### PR TITLE
fix: read back partial-create state in non-firewall resources

### DIFF
--- a/internal/service/dnsmasq/host_resource.go
+++ b/internal/service/dnsmasq/host_resource.go
@@ -72,6 +72,22 @@ func (r *hostResource) Create(ctx context.Context, req resource.CreateRequest, r
 	// Add host to dnsmasq
 	id, err := r.client.Dnsmasq().AddHost(ctx, host)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Dnsmasq().GetHost(ctx, id); readErr == nil {
+				if readModel, convErr := convertHostStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create host, got error: %s", err))
 		return

--- a/internal/service/interfaces/vip_resource.go
+++ b/internal/service/interfaces/vip_resource.go
@@ -75,6 +75,22 @@ func (r *vipResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// Add VLAN to OPNsense interfaces
 	id, err := r.client.Interfaces().AddVip(ctx, vip)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Interfaces().GetVip(ctx, id); readErr == nil {
+				if readModel, convErr := convertVipStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create vip, got error: %s", err))
 		return

--- a/internal/service/interfaces/vlan_resource.go
+++ b/internal/service/interfaces/vlan_resource.go
@@ -75,6 +75,22 @@ func (r *vlanResource) Create(ctx context.Context, req resource.CreateRequest, r
 	// Add VLAN to OPNsense interfaces
 	id, err := r.client.Interfaces().AddVlan(ctx, vlan)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Interfaces().GetVlan(ctx, id); readErr == nil {
+				if readModel, convErr := convertVlanStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create vlan, got error: %s", err))
 		return

--- a/internal/service/ipsec/auth_local_resource.go
+++ b/internal/service/ipsec/auth_local_resource.go
@@ -75,6 +75,22 @@ func (r *authLocalResource) Create(ctx context.Context, req resource.CreateReque
 	// Add IPsec Auth Local to OPNsense
 	id, err := r.client.Ipsec().AddIPsecAuthLocal(ctx, authLocal)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Ipsec().GetIPsecAuthLocal(ctx, id); readErr == nil {
+				if readModel, convErr := convertAuthLocalStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create ipsec auth local, got error: %s", err))
 		return

--- a/internal/service/ipsec/auth_remote_resource.go
+++ b/internal/service/ipsec/auth_remote_resource.go
@@ -75,6 +75,22 @@ func (r *authRemoteResource) Create(ctx context.Context, req resource.CreateRequ
 	// Add IPsec Auth Remote to OPNsense
 	id, err := r.client.Ipsec().AddIPsecAuthRemote(ctx, authRemote)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Ipsec().GetIPsecAuthRemote(ctx, id); readErr == nil {
+				if readModel, convErr := convertAuthRemoteStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create ipsec auth remote, got error: %s", err))
 		return

--- a/internal/service/ipsec/child_resource.go
+++ b/internal/service/ipsec/child_resource.go
@@ -75,6 +75,22 @@ func (r *childResource) Create(ctx context.Context, req resource.CreateRequest, 
 	// Add IPsec Child to OPNsense
 	id, err := r.client.Ipsec().AddIPsecChild(ctx, child)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Ipsec().GetIPsecChild(ctx, id); readErr == nil {
+				if readModel, convErr := convertChildStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create ipsec child, got error: %s", err))
 		return

--- a/internal/service/ipsec/connection_resource.go
+++ b/internal/service/ipsec/connection_resource.go
@@ -75,6 +75,22 @@ func (r *connectionResource) Create(ctx context.Context, req resource.CreateRequ
 	// Add IPsec Connection to OPNsense
 	id, err := r.client.Ipsec().AddIPsecConnection(ctx, connection)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Ipsec().GetIPsecConnection(ctx, id); readErr == nil {
+				if readModel, convErr := convertConnectionStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create ipsec connection, got error: %s", err))
 		return

--- a/internal/service/ipsec/psk_resource.go
+++ b/internal/service/ipsec/psk_resource.go
@@ -75,6 +75,22 @@ func (r *pskResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// Add PSK to OPNsense
 	id, err := r.client.Ipsec().AddIPsecPSK(ctx, psk)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Ipsec().GetIPsecPSK(ctx, id); readErr == nil {
+				if readModel, convErr := convertPskStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create psk, got error: %s", err))
 		return

--- a/internal/service/ipsec/vti_resource.go
+++ b/internal/service/ipsec/vti_resource.go
@@ -75,6 +75,22 @@ func (r *vtiResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// Add VTI to OPNsense
 	id, err := r.client.Ipsec().AddIPsecVTI(ctx, vti)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Ipsec().GetIPsecVTI(ctx, id); readErr == nil {
+				if readModel, convErr := convertVtiStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create vti, got error: %s", err))
 		return

--- a/internal/service/kea/dhcpv4_peer_resource.go
+++ b/internal/service/kea/dhcpv4_peer_resource.go
@@ -70,6 +70,22 @@ func (r *dhcpv4PeerResource) Create(ctx context.Context, req resource.CreateRequ
 
 	id, err := r.client.Kea().AddPeerV4(ctx, peer)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetPeerV4(ctx, id); readErr == nil {
+				if readModel, convErr := convertDhcpv4PeerStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create peer, got error: %s", err))
 		return

--- a/internal/service/kea/dhcpv4_reservation_resource.go
+++ b/internal/service/kea/dhcpv4_reservation_resource.go
@@ -70,6 +70,22 @@ func (r *dhcpv4ReservationResource) Create(ctx context.Context, req resource.Cre
 
 	id, err := r.client.Kea().AddReservationV4(ctx, reservation)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetReservationV4(ctx, id); readErr == nil {
+				if readModel, convErr := convertDhcpv4ReservationStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create reservation, got error: %s", err))
 		return

--- a/internal/service/kea/dhcpv4_subnet_resource.go
+++ b/internal/service/kea/dhcpv4_subnet_resource.go
@@ -70,6 +70,22 @@ func (r *dhcpv4SubnetResource) Create(ctx context.Context, req resource.CreateRe
 
 	id, err := r.client.Kea().AddSubnetV4(ctx, subnet)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetSubnetV4(ctx, id); readErr == nil {
+				if readModel, convErr := convertDhcpv4SubnetStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create subnet, got error: %s", err))
 		return

--- a/internal/service/kea/dhcpv6_pd_pool_resource.go
+++ b/internal/service/kea/dhcpv6_pd_pool_resource.go
@@ -70,6 +70,22 @@ func (r *dhcpv6PdPoolResource) Create(ctx context.Context, req resource.CreateRe
 
 	id, err := r.client.Kea().AddPDPool(ctx, pdPool)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetPDPool(ctx, id); readErr == nil {
+				if readModel, convErr := convertDhcpv6PdPoolStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create pd_pool, got error: %s", err))
 		return

--- a/internal/service/kea/dhcpv6_peer_resource.go
+++ b/internal/service/kea/dhcpv6_peer_resource.go
@@ -70,6 +70,22 @@ func (r *dhcpv6PeerResource) Create(ctx context.Context, req resource.CreateRequ
 
 	id, err := r.client.Kea().AddPeerV6(ctx, peer)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetPeerV6(ctx, id); readErr == nil {
+				if readModel, convErr := convertDhcpv6PeerStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create peer, got error: %s", err))
 		return

--- a/internal/service/kea/dhcpv6_reservation_resource.go
+++ b/internal/service/kea/dhcpv6_reservation_resource.go
@@ -70,6 +70,22 @@ func (r *dhcpv6ReservationResource) Create(ctx context.Context, req resource.Cre
 
 	id, err := r.client.Kea().AddReservationV6(ctx, reservation)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetReservationV6(ctx, id); readErr == nil {
+				if readModel, convErr := convertDhcpv6ReservationStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create reservation, got error: %s", err))
 		return

--- a/internal/service/kea/dhcpv6_subnet_resource.go
+++ b/internal/service/kea/dhcpv6_subnet_resource.go
@@ -70,6 +70,22 @@ func (r *dhcpv6SubnetResource) Create(ctx context.Context, req resource.CreateRe
 
 	id, err := r.client.Kea().AddSubnetV6(ctx, subnet)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetSubnetV6(ctx, id); readErr == nil {
+				if readModel, convErr := convertDhcpv6SubnetStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create subnet, got error: %s", err))
 		return

--- a/internal/service/kea/peer_resource.go
+++ b/internal/service/kea/peer_resource.go
@@ -75,6 +75,22 @@ func (r *peerResource) Create(ctx context.Context, req resource.CreateRequest, r
 	// Add peer to kea
 	id, err := r.client.Kea().AddPeerV4(ctx, peer)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetPeerV4(ctx, id); readErr == nil {
+				if readModel, convErr := convertPeerStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create peer, got error: %s", err))
 		return

--- a/internal/service/kea/reservation_resource.go
+++ b/internal/service/kea/reservation_resource.go
@@ -75,6 +75,22 @@ func (r *reservationResource) Create(ctx context.Context, req resource.CreateReq
 	// Add reservation to kea
 	id, err := r.client.Kea().AddReservationV4(ctx, reservation)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetReservationV4(ctx, id); readErr == nil {
+				if readModel, convErr := convertReservationStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create reservation, got error: %s", err))
 		return

--- a/internal/service/kea/subnet_resource.go
+++ b/internal/service/kea/subnet_resource.go
@@ -75,6 +75,22 @@ func (r *subnetResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Add subnet to kea
 	id, err := r.client.Kea().AddSubnetV4(ctx, subnet)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Kea().GetSubnetV4(ctx, id); readErr == nil {
+				if readModel, convErr := convertSubnetStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create forward, got error: %s", err))
 		return

--- a/internal/service/quagga/bgp_aspath_resource.go
+++ b/internal/service/quagga/bgp_aspath_resource.go
@@ -75,6 +75,22 @@ func (r *bgpASPathResource) Create(ctx context.Context, req resource.CreateReque
 	// Add bgp aspath to unbound
 	id, err := r.client.Quagga().AddBGPASPath(ctx, bgpASPath)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Quagga().GetBGPASPath(ctx, id); readErr == nil {
+				if readModel, convErr := convertBGPASPathStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create bgp aspath, got error: %s", err))
 		return

--- a/internal/service/quagga/bgp_communitylist_resource.go
+++ b/internal/service/quagga/bgp_communitylist_resource.go
@@ -75,6 +75,22 @@ func (r *bgpCommunityListResource) Create(ctx context.Context, req resource.Crea
 	// Add bgp community list to unbound
 	id, err := r.client.Quagga().AddBGPCommunityList(ctx, bgpCommunityList)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Quagga().GetBGPCommunityList(ctx, id); readErr == nil {
+				if readModel, convErr := convertBGPCommunityListStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create bgp community list, got error: %s", err))
 		return

--- a/internal/service/quagga/bgp_neighbor_resource.go
+++ b/internal/service/quagga/bgp_neighbor_resource.go
@@ -75,6 +75,22 @@ func (r *bgpNeighborResource) Create(ctx context.Context, req resource.CreateReq
 	// Add bgp neighbor to unbound
 	id, err := r.client.Quagga().AddBGPNeighbor(ctx, bgpNeighbor)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Quagga().GetBGPNeighbor(ctx, id); readErr == nil {
+				if readModel, convErr := convertBGPNeighborStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create bgp neighbor, got error: %s", err))
 		return

--- a/internal/service/quagga/bgp_prefixlist_resource.go
+++ b/internal/service/quagga/bgp_prefixlist_resource.go
@@ -75,6 +75,22 @@ func (r *bgpPrefixListResource) Create(ctx context.Context, req resource.CreateR
 	// Add bgp prefix list to unbound
 	id, err := r.client.Quagga().AddBGPPrefixList(ctx, bgpPrefixList)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Quagga().GetBGPPrefixList(ctx, id); readErr == nil {
+				if readModel, convErr := convertBGPPrefixListStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create bgp prefix list, got error: %s", err))
 		return

--- a/internal/service/quagga/bgp_routemap_resource.go
+++ b/internal/service/quagga/bgp_routemap_resource.go
@@ -75,6 +75,22 @@ func (r *bgpRouteMapResource) Create(ctx context.Context, req resource.CreateReq
 	// Add bgp route map to unbound
 	id, err := r.client.Quagga().AddBGPRouteMap(ctx, bgpRouteMap)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Quagga().GetBGPRouteMap(ctx, id); readErr == nil {
+				if readModel, convErr := convertBGPRouteMapStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create bgp route map, got error: %s", err))
 		return

--- a/internal/service/routes/route_resource.go
+++ b/internal/service/routes/route_resource.go
@@ -75,6 +75,22 @@ func (r *routeResource) Create(ctx context.Context, req resource.CreateRequest, 
 	// Add route to unbound
 	id, err := r.client.Routes().AddRoute(ctx, route)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Routes().GetRoute(ctx, id); readErr == nil {
+				if readModel, convErr := convertRouteStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create route, got error: %s", err))
 		return

--- a/internal/service/unbound/domain_override_resource.go
+++ b/internal/service/unbound/domain_override_resource.go
@@ -75,6 +75,22 @@ func (r *domainOverrideResource) Create(ctx context.Context, req resource.Create
 	// Add domain override to unbound
 	id, err := r.client.Unbound().AddDomainOverride(ctx, domainOverride)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Unbound().GetDomainOverride(ctx, id); readErr == nil {
+				if readModel, convErr := convertDomainOverrideStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create domain override, got error: %s", err))
 		return

--- a/internal/service/unbound/forward_resource.go
+++ b/internal/service/unbound/forward_resource.go
@@ -75,6 +75,22 @@ func (r *forwardResource) Create(ctx context.Context, req resource.CreateRequest
 	// Add forward to unbound
 	id, err := r.client.Unbound().AddForward(ctx, forward)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Unbound().GetForward(ctx, id); readErr == nil {
+				if readModel, convErr := convertForwardStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create forward, got error: %s", err))
 		return

--- a/internal/service/unbound/host_alias_resource.go
+++ b/internal/service/unbound/host_alias_resource.go
@@ -75,6 +75,22 @@ func (r *hostAliasResource) Create(ctx context.Context, req resource.CreateReque
 	// Add host alias to unbound
 	id, err := r.client.Unbound().AddHostAlias(ctx, hostAlias)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Unbound().GetHostAlias(ctx, id); readErr == nil {
+				if readModel, convErr := convertHostAliasStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create host alias, got error: %s", err))
 		return

--- a/internal/service/unbound/host_override_resource.go
+++ b/internal/service/unbound/host_override_resource.go
@@ -75,6 +75,22 @@ func (r *hostOverrideResource) Create(ctx context.Context, req resource.CreateRe
 	// Add host override to unbound
 	id, err := r.client.Unbound().AddHostOverride(ctx, hostOverride)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Unbound().GetHostOverride(ctx, id); readErr == nil {
+				if readModel, convErr := convertHostOverrideStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create host override, got error: %s", err))
 		return

--- a/internal/service/wireguard/client_resource.go
+++ b/internal/service/wireguard/client_resource.go
@@ -75,6 +75,22 @@ func (r *clientResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Add wg client to unbound
 	id, err := r.client.Wireguard().AddClient(ctx, wgClient)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Wireguard().GetClient(ctx, id); readErr == nil {
+				if readModel, convErr := convertClientStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create wg client, got error: %s", err))
 		return

--- a/internal/service/wireguard/server_resource.go
+++ b/internal/service/wireguard/server_resource.go
@@ -75,6 +75,22 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Add wg server to unbound
 	id, err := r.client.Wireguard().AddServer(ctx, wgServer)
 	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+
+			// Read back so state captures API-normalised values (defaults,
+			// sorting, trimming); fall back to plan-only state if the
+			// read-back fails so the upstream resource isn't orphaned.
+			if readStruct, readErr := r.client.Wireguard().GetServer(ctx, id); readErr == nil {
+				if readModel, convErr := convertServerStructToSchema(readStruct); convErr == nil {
+					readModel.Id = data.Id
+					data = readModel
+				}
+			}
+
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
 		resp.Diagnostics.AddError("Client Error",
 			fmt.Sprintf("Unable to create wg server, got error: %s", err))
 		return


### PR DESCRIPTION
## Description
PR #130 added a partial-create rescue to the firewall resources: when `Add*` returns a UUID together with an error (the upstream resource was created but the post-save reconfigure failed), the resource saves the ID and reads back from upstream so Terraform state stays in sync with what actually exists.

This PR mirrors that pattern to every non-firewall resource Create handler so they no longer drop the UUID and orphan the upstream resource on a partial failure:

- `dnsmasq/host_resource.go`
- `interfaces/{vip,vlan}_resource.go`
- `ipsec/{auth_local,auth_remote,child,connection,psk,vti}_resource.go`
- `kea/{dhcpv4_peer,dhcpv4_reservation,dhcpv4_subnet,dhcpv6_pd_pool,dhcpv6_peer,dhcpv6_reservation,dhcpv6_subnet,peer,reservation,subnet}_resource.go`
- `quagga/bgp_{aspath,communitylist,neighbor,prefixlist,routemap}_resource.go`
- `routes/route_resource.go`
- `unbound/{domain_override,forward,host_alias,host_override}_resource.go`
- `wireguard/{client,server}_resource.go`

`opnsense_unbound_settings` is excluded — it's a singleton with no `Add`.

## Related Issues
N/A — follow-up to #130.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
None — only the partial-failure recovery path changes. The happy path is untouched.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: no schema change

**Explanation**: Resource-handler logic only. Schemas untouched.

## Testing
- [ ] Unit tests added/updated
- [ ] Acceptance tests added/updated

Build / vet clean across the full tree. The +16-line delta is identical in every file. Reproducing the rescue path requires upstream returning UUID + error simultaneously (reconfigure failing after add), which isn't deterministic from acceptance tests; behaviour is preserved on the happy path.

## Examples
- [x] N/A

## Environment
- **OPNsense version tested**: N/A (rescue path is a rare-error logic mirror of #130)
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`) — no diff (no schema change)
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code released in opnsense-go — N/A
- [ ] Tests pass locally & in test workflow