### PR TITLE
feat(firewall): validate path_expression usage matches alias type

### DIFF
--- a/internal/service/firewall/alias_resource.go
+++ b/internal/service/firewall/alias_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/errs"
 	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/browningluke/terraform-provider-opnsense/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -18,6 +19,7 @@ import (
 var _ resource.Resource = &aliasResource{}
 var _ resource.ResourceWithConfigure = &aliasResource{}
 var _ resource.ResourceWithImportState = &aliasResource{}
+var _ resource.ResourceWithConfigValidators = &aliasResource{}
 
 func newAliasResource() resource.Resource {
 	return &aliasResource{}
@@ -34,6 +36,23 @@ func (r *aliasResource) Metadata(ctx context.Context, req resource.MetadataReque
 
 func (r *aliasResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = aliasResourceSchema()
+}
+
+func (r *aliasResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		// path_expression only applies when type = "urljson"
+		validators.RequiresStringEqualsOneOf(
+			path.MatchRoot("path_expression"),
+			path.MatchRoot("type"),
+			[]string{"urljson"},
+		),
+		// path_expression must be set when type = "urljson"
+		validators.RequiredWhenStringEqualsOneOf(
+			path.MatchRoot("path_expression"),
+			path.MatchRoot("type"),
+			[]string{"urljson"},
+		),
+	}
 }
 
 func (r *aliasResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/service/firewall/alias_resource_test.go
+++ b/internal/service/firewall/alias_resource_test.go
@@ -2,6 +2,7 @@ package firewall_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
@@ -141,6 +142,45 @@ func TestAccFirewallAliasResource_URLJson(t *testing.T) {
 					resource.TestCheckResourceAttr("opnsense_firewall_alias.test", "description", "URL JSON alias updated"),
 					resource.TestCheckResourceAttr("opnsense_firewall_alias.test", "path_expression", ".web | .[]"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFirewallAliasResource_PathExpressionWrongType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "opnsense_firewall_alias" "test" {
+  name            = "badalias"
+  type            = "host"
+  content         = ["192.168.1.100"]
+  path_expression = ".foo"
+}
+`,
+				ExpectError: regexp.MustCompile(`(?s)path_expression.*type.*urljson`),
+			},
+		},
+	})
+}
+
+func TestAccFirewallAliasResource_URLJsonMissingPathExpression(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "opnsense_firewall_alias" "test" {
+  name    = "urljsonmissing"
+  type    = "urljson"
+  content = ["https://api.github.com/meta"]
+}
+`,
+				ExpectError: regexp.MustCompile(`(?s)path_expression must be set.*type.*urljson`),
 			},
 		},
 	})

--- a/internal/validators/required_when_string_equals.go
+++ b/internal/validators/required_when_string_equals.go
@@ -1,0 +1,186 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// requiredWhenStringEqualsOneOfValidator is a resource-level validator that ensures
+// when a condition attribute equals one of the specified values, a dependent attribute must be set.
+type requiredWhenStringEqualsOneOfValidator struct {
+	dependentPath path.Expression
+	conditionPath path.Expression
+	triggerValues []string
+}
+
+// Description returns a plain text description of the validator's behavior.
+func (v requiredWhenStringEqualsOneOfValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("When %q equals one of: %s, %q must be set",
+		v.conditionPath.String(), strings.Join(v.triggerValues, ", "), v.dependentPath.String())
+}
+
+// MarkdownDescription returns a markdown formatted description of the validator's behavior.
+func (v requiredWhenStringEqualsOneOfValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateResource performs the validation.
+func (v requiredWhenStringEqualsOneOfValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	// Read the condition value
+	conditionValue, diags := v.getStringValue(ctx, req, v.conditionPath)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	// Condition unknown/missing — nothing to enforce here
+	if conditionValue == nil {
+		return
+	}
+
+	// Check whether the condition value triggers the requirement
+	triggered := false
+	for _, t := range v.triggerValues {
+		if *conditionValue == t {
+			triggered = true
+			break
+		}
+	}
+	if !triggered {
+		return
+	}
+
+	// Condition is triggered — dependent must be set
+	isSet, diags := v.isDependentFieldSet(ctx, req, v.dependentPath)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	if isSet {
+		return
+	}
+
+	resp.Diagnostics.AddError(
+		"Missing Required Attribute",
+		fmt.Sprintf("%s must be set when %s equals one of: %s",
+			v.dependentPath.String(),
+			v.conditionPath.String(),
+			strings.Join(v.triggerValues, ", "),
+		),
+	)
+}
+
+// isDependentFieldSet checks if the dependent field is set (non-default/non-empty).
+// Supports all Terraform types: Int64, String, Bool, Float64, Number, Set, List, Map, Object.
+// Returns false if the field is null, unknown, or considered "not set" based on type-specific logic.
+func (v requiredWhenStringEqualsOneOfValidator) isDependentFieldSet(ctx context.Context, req resource.ValidateConfigRequest, expression path.Expression) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	matchedPaths, pathDiags := req.Config.PathMatches(ctx, expression)
+	diags.Append(pathDiags...)
+	if pathDiags.HasError() {
+		return false, diags
+	}
+	if len(matchedPaths) == 0 {
+		return false, diags
+	}
+
+	var matchedPathValue attr.Value
+	getDiags := req.Config.GetAttribute(ctx, matchedPaths[0], &matchedPathValue)
+	diags.Append(getDiags...)
+	if getDiags.HasError() {
+		return false, diags
+	}
+
+	if matchedPathValue.IsNull() || matchedPathValue.IsUnknown() {
+		return false, diags
+	}
+
+	switch value := matchedPathValue.(type) {
+	case types.Int64:
+		return value.ValueInt64() != -1, diags
+	case types.String:
+		return value.ValueString() != "", diags
+	case types.Bool:
+		return true, diags
+	case types.Float64:
+		return true, diags
+	case types.Number:
+		return true, diags
+	case types.Set:
+		return len(value.Elements()) > 0, diags
+	case types.List:
+		return len(value.Elements()) > 0, diags
+	case types.Map:
+		return len(value.Elements()) > 0, diags
+	case types.Object:
+		return true, diags
+	default:
+		return true, diags
+	}
+}
+
+// getStringValue extracts a String value from the given path expression.
+// Returns nil if the value is null or unknown.
+func (v requiredWhenStringEqualsOneOfValidator) getStringValue(ctx context.Context, req resource.ValidateConfigRequest, expression path.Expression) (*string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	matchedPaths, pathDiags := req.Config.PathMatches(ctx, expression)
+	diags.Append(pathDiags...)
+	if pathDiags.HasError() {
+		return nil, diags
+	}
+	if len(matchedPaths) == 0 {
+		return nil, diags
+	}
+
+	var matchedPathValue attr.Value
+	getDiags := req.Config.GetAttribute(ctx, matchedPaths[0], &matchedPathValue)
+	diags.Append(getDiags...)
+	if getDiags.HasError() {
+		return nil, diags
+	}
+
+	if matchedPathValue.IsNull() || matchedPathValue.IsUnknown() {
+		return nil, diags
+	}
+
+	var value types.String
+	valueDiags := tfsdk.ValueAs(ctx, matchedPathValue, &value)
+	diags.Append(valueDiags...)
+	if valueDiags.HasError() {
+		return nil, diags
+	}
+
+	stringValue := value.ValueString()
+	return &stringValue, diags
+}
+
+// RequiredWhenStringEqualsOneOf returns a validator that ensures when the condition
+// field equals one of the specified trigger values, the dependent field must be set.
+//
+// Supports all Terraform types for the dependent field; see RequiresStringEqualsOneOf
+// for the "is set" semantics applied per type. The condition field must be a String.
+//
+// Example: Ensure path_expression is set when type is "urljson":
+//
+//	validators.RequiredWhenStringEqualsOneOf(
+//	    path.MatchRoot("path_expression"),
+//	    path.MatchRoot("type"),
+//	    []string{"urljson"},
+//	)
+func RequiredWhenStringEqualsOneOf(dependentPath, conditionPath path.Expression, triggerValues []string) resource.ConfigValidator {
+	return requiredWhenStringEqualsOneOfValidator{
+		dependentPath: dependentPath,
+		conditionPath: conditionPath,
+		triggerValues: triggerValues,
+	}
+}


### PR DESCRIPTION
## Description
Adds resource-level config validators on `opnsense_firewall_alias` so that the `path_expression` attribute is only accepted when `type = "urljson"`, and is required when `type = "urljson"`. This catches the misconfiguration at plan time instead of letting it surface as an OPNsense API error during apply.

Also adds a new `RequiredWhenStringEqualsOneOf` validator helper as the inverse of the existing `RequiresStringEqualsOneOf` helper, since the description for `path_expression` enforces the requirement in both directions.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
N/A — this is purely additional validation. Existing valid configurations continue to plan and apply unchanged.

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: v0 exception applies (explain why below)

**Explanation**: No schema-shape changes — only resource-level config validators are added. Any state that previously planned/applied successfully will continue to do so.

## Testing
- [ ] Unit tests added/updated (optional, but encouraged)
- [x] Acceptance tests added/updated (mandatory)

Two new acceptance tests cover both directions of the validator:
- `TestAccFirewallAliasResource_PathExpressionWrongType` — sets `path_expression` on a non-`urljson` alias and asserts the validator rejects it.
- `TestAccFirewallAliasResource_URLJsonMissingPathExpression` — sets `type = "urljson"` without `path_expression` and asserts the validator rejects it.

All existing alias acceptance tests still pass against a local OPNsense VM.

## Examples
- [ ] Examples added/updated in `examples/` directory
- [x] N/A - No user-facing schema changes

## Environment
- **OPNsense version tested**: local QEMU VM (latest community image)
- **Terraform version**: per `terraform-plugin-testing` defaults

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`) — N/A (no schema/attribute changes)
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go) — N/A (provider-side validation only)
- [x] Tests pass locally & in test workflow