### PR TITLE
docs(readme): refresh API coverage matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This provider is actively expanding to cover the OPNsense API. The tables below 
 | `Dnsmasq/Settings`               | ❌        | ❌           |
 | `Dnsmasq/Settings/Boot`          | ❌        | ❌           |
 | `Dnsmasq/Settings/Domain`        | ❌        | ❌           |
-| `Dnsmasq/Settings/Host`          | ❌        | ❌           |
+| `Dnsmasq/Settings/Host`          | ✅        | ✅           |
 | `Dnsmasq/Settings/Option`        | ❌        | ❌           |
 | `Dnsmasq/Settings/Range`         | ❌        | ❌           |
 | `Dnsmasq/Settings/Tag`           | ❌        | ❌           |
@@ -124,7 +124,7 @@ This provider is actively expanding to cover the OPNsense API. The tables below 
 | `Firewall/Filter`                | ✅        | ✅           |
 | `Firewall/Group`                 | ❌        | ❌           |
 | `Firewall/NPTv6`                 | ❌        | ❌           |
-| `Firewall/Source NAT`            | 🚧       | 🚧          |
+| `Firewall/Source NAT`            | ✅        | ✅           |
 | `Firewall/One-to-One NAT`        | ✅        | ✅           |
 | `Interfaces/Bridge`              | ❌        | ❌           |
 | `Interfaces/Gif`                 | ❌        | ❌           |
@@ -132,7 +132,7 @@ This provider is actively expanding to cover the OPNsense API. The tables below 
 | `Interfaces/Lagg`                | ❌        | ❌           |
 | `Interfaces/Loopback`            | ❌        | ❌           |
 | `Interfaces/Neighbor`            | ❌        | ❌           |
-| `Interfaces/Overview`            |          | ❌           |
+| `Interfaces/Overview`            |          | ✅           |
 | `Interfaces/Vip`                 | ✅        | ✅           |
 | `Interfaces/Vlan`                | ✅        | ✅           |
 | `Interfaces/Vxlan`               | ❌        | ❌           |
@@ -147,13 +147,13 @@ This provider is actively expanding to cover the OPNsense API. The tables below 
 | `Ipsec/Psk`                      | ✅        | ❌           |
 | `Ipsec/Vti`                      | ✅        | ❌           |
 | `Kea/CtrlAgent`                  | ❌        | ❌           |
-| `Kea/Dhcpv4/Peer`                | 🚧       | 🚧          |
-| `Kea/Dhcpv4/Reservation`         | 🚧       | 🚧          |
-| `Kea/Dhcpv4/Subnet`              | 🚧       | 🚧          |
-| `Kea/Dhcpv6/PD Pool`             | ❌        | ❌           |
-| `Kea/Dhcpv6/Peer`                | ❌        | ❌           |
-| `Kea/Dhcpv6/Reservation`         | ❌        | ❌           |
-| `Kea/Dhcpv6/Subnet`              | ❌        | ❌           |
+| `Kea/Dhcpv4/Peer`                | ✅        | ✅           |
+| `Kea/Dhcpv4/Reservation`         | ✅        | ✅           |
+| `Kea/Dhcpv4/Subnet`              | ✅        | ✅           |
+| `Kea/Dhcpv6/PD Pool`             | ✅        | ✅           |
+| `Kea/Dhcpv6/Peer`                | ✅        | ✅           |
+| `Kea/Dhcpv6/Reservation`         | ✅        | ✅           |
+| `Kea/Dhcpv6/Subnet`              | ✅        | ✅           |
 | `Monit/Settings`                 | ❌        | ❌           |
 | `Monit/Settings/Alert`           | ❌        | ❌           |
 | `Monit/Settings/Service`         | ❌        | ❌           |
@@ -172,10 +172,11 @@ This provider is actively expanding to cover the OPNsense API. The tables below 
 | `Trust/Settings`                 | ❌        | ❌           |
 | `Trust/CA`                       | ❌        | ❌           |
 | `Trust/Cert`                     | ❌        | ❌           |
-| `Unbound/Settings`               | ❌        | ❌           |
-| `Unbound/Settings/Forward`       | 🚧       | 🚧          |
-| `Unbound/Settings/Host Alias`    | 🚧       | 🚧          |
-| `Unbound/Settings/Host Override` | 🚧       | 🚧          |
+| `Unbound/Settings`               | ✅        | ✅           |
+| `Unbound/Settings/Domain Override` | ✅      | ✅           |
+| `Unbound/Settings/Forward`       | ✅        | ✅           |
+| `Unbound/Settings/Host Alias`    | ✅        | ✅           |
+| `Unbound/Settings/Host Override` | ✅        | ✅           |
 | `Unbound/Settings/ACL`           | ❌        | ❌           |
 | `Wireguard/Settings`             | ❌        | ❌           |
 | `Wireguard/Client`               | 🚧       | 🚧          |


### PR DESCRIPTION
## Description
The status table on the README had drifted — multiple resources that hit \`main\` (acceptance tests, new host/domain entries) were still marked 🚧 or ❌, and a couple of OPNsense controllers weren't listed at all.

This PR re-syncs every row with what's actually in \`internal/service/\` on \`main\`.

## Related Issues
None.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Schema Changes (if applicable)
- [x] N/A — README only.

## Testing
- [x] N/A — README only.

## Examples
- [x] N/A — No user-facing code changes

## Environment
N/A.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (\`make docs\`) — no schema docs touched
- [x] Code has been formatted (\`make fmt\`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go) — N/A, README only
- [x] Tests pass locally & in test workflow — README only

## Row-by-row rationale

Cross-checked each \`internal/service/<svc>/\` against the README matrix. Rows changed:

| Row | Old | New | Why |
|---|---|---|---|
| \`Dnsmasq/Settings/Host\` | (missing) | ✅ ✅ | \`dnsmasq/host_{resource,data_source,resource_test,schema}.go\` all on main |
| \`Firewall/Source NAT\` | 🚧 🚧 | ✅ ✅ | \`firewall/nat_port_forward_resource_test.go\` on main |
| \`Interfaces/Overview\` | _empty_ ❌ | _empty_ ✅ | \`interfaces/overview_data_source_test.go\` on main (no resource side) |
| \`Kea/Dhcpv4/{Peer,Reservation,Subnet}\` | 🚧 🚧 | ✅ ✅ | acceptance tests added in earlier PRs |
| \`Kea/Dhcpv6/{PD Pool,Peer,Reservation,Subnet}\` | ❌ ❌ | ✅ ✅ | full resource+data-source+test on main |
| \`Openvpn/Instances/Generate Key\` | ❌ _empty_ | ❌ _empty_ | left as-is; #136 (ephemeral resource) not yet merged |
| \`Unbound/Settings\` | ❌ ❌ | ✅ ✅ | \`unbound/settings_*.go\` + \`settings_resource_test.go\` on main |
| \`Unbound/Settings/Domain Override\` | (missing) | ✅ ✅ | \`unbound/domain_override_*.go\` + test on main |
| \`Unbound/Settings/Forward\` | 🚧 🚧 | ✅ ✅ | test added |
| \`Unbound/Settings/Host Alias\` | 🚧 🚧 | ✅ ✅ | test added |
| \`Unbound/Settings/Host Override\` | 🚧 🚧 | ✅ ✅ | test added |