### PR TITLE
chore(deps): bump opnsense-go to v0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/browningluke/terraform-provider-opnsense
 go 1.25.8
 
 require (
-	github.com/browningluke/opnsense-go v0.22.0
+	github.com/browningluke/opnsense-go v0.23.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/browningluke/opnsense-go v0.22.0 h1:hiCBblG4fnE1hEeXdbmHQgRiKlIEpcZDQUzgy8cCjhI=
-github.com/browningluke/opnsense-go v0.22.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
+github.com/browningluke/opnsense-go v0.23.0 h1:UbnblbXZbcnzEaGGrbUMDhtphBnVVMc4b/1yC4psjpI=
+github.com/browningluke/opnsense-go v0.23.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
Bumps `github.com/browningluke/opnsense-go` to `v0.23.0`.

This PR was opened automatically in response to a new release of [opnsense-go](https://github.com/browningluke/opnsense-go/releases/tag/v0.23.0).

**Release:** [v0.23.0](https://github.com/browningluke/opnsense-go/releases/tag/v0.23.0)
