### PR TITLE
fix(firewall): preserve empty-string interface for nat_port_forward

### DIFF
--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -391,6 +391,23 @@ func natPortForwardInterfaceStringToSet(s string) types.Set {
 	return types.SetValueMust(types.StringType, interfaces)
 }
 
+func natPortForwardInterfaceSliceToSet(s []string) types.Set {
+	seen := make(map[string]struct{})
+	var list []attr.Value
+	for _, iface := range s {
+		if _, ok := seen[iface]; ok {
+			continue
+		}
+		seen[iface] = struct{}{}
+		list = append(list, types.StringValue(iface))
+	}
+	if len(list) == 0 {
+		sv, _ := types.SetValue(types.StringType, []attr.Value{})
+		return sv
+	}
+	return types.SetValueMust(types.StringType, list)
+}
+
 func convertNATPortForwardSchemaToStruct(d *natPortForwardResourceModel) (*firewall.NatPortForward, error) {
 	return &firewall.NatPortForward{
 		// Schema uses "enabled" (user-friendly), API uses "disabled" (inverted).
@@ -431,7 +448,7 @@ func convertNATPortForwardStructToSchema(d *firewall.NatPortForward) (*natPortFo
 		// API uses "disabled" (inverted), schema uses "enabled" (user-friendly).
 		Enabled:    types.BoolValue(!tools.StringToBool(d.Disabled)),
 		Sequence:   tools.StringToInt64Null(d.Sequence),
-		Interface:  tools.StringSliceToSet([]string(d.Interface)),
+		Interface:  natPortForwardInterfaceSliceToSet([]string(d.Interface)),
 		IPProtocol: types.StringValue(d.IPProtocol.String()),
 		Protocol:   types.StringValue(d.Protocol.String()),
 		Source: &firewallLocation{

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -401,11 +401,8 @@ func natPortForwardInterfaceSliceToSet(s []string) types.Set {
 		seen[iface] = struct{}{}
 		list = append(list, types.StringValue(iface))
 	}
-	if len(list) == 0 {
-		sv, _ := types.SetValue(types.StringType, []attr.Value{})
-		return sv
-	}
-	return types.SetValueMust(types.StringType, list)
+	sv, _ := types.SetValue(types.StringType, list)
+	return sv
 }
 
 func convertNATPortForwardSchemaToStruct(d *natPortForwardResourceModel) (*firewall.NatPortForward, error) {

--- a/internal/service/firewall/nat_port_forward_schema_test.go
+++ b/internal/service/firewall/nat_port_forward_schema_test.go
@@ -136,6 +136,34 @@ func TestConvertNATPortForwardStructToSchema(t *testing.T) {
 	require.Equal(t, "Updated WAN HTTPS", result.Description.ValueString())
 }
 
+func TestConvertNATPortForwardStructToSchemaAnyInterface(t *testing.T) {
+	result, err := convertNATPortForwardStructToSchema(&opnfirewall.NatPortForward{
+		Disabled:   "0",
+		Sequence:   "1",
+		Interface:  api.SelectedMapList{""},
+		IPProtocol: "inet",
+		Protocol:   "tcp",
+		Source: opnfirewall.NatPortForwardLocation{
+			Network: "",
+			Port:    "",
+			Invert:  "0",
+		},
+		Destination: opnfirewall.NatPortForwardLocation{
+			Network: "wanip",
+			Port:    "443",
+			Invert:  "0",
+		},
+		Target:        "10.0.0.1",
+		TargetPort:    "443",
+		Log:           "0",
+		NatReflection: "",
+		Description:   "Example",
+	})
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{""}, tools.SetToStringSlice(result.Interface))
+}
+
 func TestNatPortForwardInterfaceStringToSet(t *testing.T) {
 	result := natPortForwardInterfaceStringToSet("wan, openvpn,,lan")
 


### PR DESCRIPTION
## Summary

- `opnsense_firewall_nat_port_forward` uses `""` (empty string) as the OPNsense API key for the "any" interface
- `convertNATPortForwardStructToSchema` was passing the interface list through `tools.StringSliceToSet`, which explicitly skips empty strings
- This dropped the `""` element on every read, leaving state as `[]` while the user's config kept `[""]`, producing a perpetual diff

## Changes

- Add `natPortForwardInterfaceSliceToSet` — same dedup logic as `StringSliceToSet` but preserves empty strings, since `""` is a valid interface selector (meaning "any") for this field
- Use it in `convertNATPortForwardStructToSchema` instead of `tools.StringSliceToSet`
- Add `TestConvertNATPortForwardStructToSchemaAnyInterface` to cover this case

## Test plan

- [ ] `go test ./internal/service/firewall/... -run "TestConvertNATPortForward|TestNatPortForward"` passes
- [ ] `interface = [""]` in config produces no diff after apply

Closes #148