### PR TITLE
refactor: internal cleanup — validators, type_utils, factory functions

### DIFF
--- a/internal/service/diagnostics/exports.go
+++ b/internal/service/diagnostics/exports.go
@@ -13,7 +13,7 @@ func Resources(ctx context.Context) []func() resource.Resource {
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newInterfaceDataSource,
-		newInterfaceAllDataSource,
+		func() datasource.DataSource { return &interfaceDataSource{} },
+		func() datasource.DataSource { return &interfaceAllDataSource{} },
 	}
 }

--- a/internal/service/diagnostics/interface_all_data_source.go
+++ b/internal/service/diagnostics/interface_all_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &interfaceAllDataSource{}
 var _ datasource.DataSourceWithConfigure = &interfaceAllDataSource{}
 
-func newInterfaceAllDataSource() datasource.DataSource {
-	return &interfaceAllDataSource{}
-}
 
 // interfaceAllDataSource defines the data source implementation.
 type interfaceAllDataSource struct {

--- a/internal/service/diagnostics/interface_data_source.go
+++ b/internal/service/diagnostics/interface_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &interfaceDataSource{}
 var _ datasource.DataSourceWithConfigure = &interfaceDataSource{}
 
-func newInterfaceDataSource() datasource.DataSource {
-	return &interfaceDataSource{}
-}
 
 // interfaceDataSource defines the data source implementation.
 type interfaceDataSource struct {

--- a/internal/service/dnsmasq/exports.go
+++ b/internal/service/dnsmasq/exports.go
@@ -9,12 +9,12 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		NewHostResource,
+		func() resource.Resource { return &hostResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newClientDataSource,
+		func() datasource.DataSource { return &hostDataSource{} },
 	}
 }

--- a/internal/service/dnsmasq/host_data_source.go
+++ b/internal/service/dnsmasq/host_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &hostDataSource{}
 var _ datasource.DataSourceWithConfigure = &hostDataSource{}
 
-func newClientDataSource() datasource.DataSource {
-	return &hostDataSource{}
-}
 
 type hostDataSource struct {
 	client opnsense.Client

--- a/internal/service/dnsmasq/host_resource.go
+++ b/internal/service/dnsmasq/host_resource.go
@@ -18,9 +18,6 @@ var _ resource.Resource = &hostResource{}
 var _ resource.ResourceWithConfigure = &hostResource{}
 var _ resource.ResourceWithImportState = &hostResource{}
 
-func NewHostResource() resource.Resource {
-	return &hostResource{}
-}
 
 type hostResource struct {
 	client opnsense.Client

--- a/internal/service/firewall/alias_data_source.go
+++ b/internal/service/firewall/alias_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &aliasDataSource{}
 var _ datasource.DataSourceWithConfigure = &aliasDataSource{}
 
-func newAliasDataSource() datasource.DataSource {
-	return &aliasDataSource{}
-}
 
 // aliasDataSource defines the data source implementation.
 type aliasDataSource struct {

--- a/internal/service/firewall/alias_resource.go
+++ b/internal/service/firewall/alias_resource.go
@@ -21,9 +21,6 @@ var _ resource.ResourceWithConfigure = &aliasResource{}
 var _ resource.ResourceWithImportState = &aliasResource{}
 var _ resource.ResourceWithConfigValidators = &aliasResource{}
 
-func newAliasResource() resource.Resource {
-	return &aliasResource{}
-}
 
 // aliasResource defines the resource implementation.
 type aliasResource struct {

--- a/internal/service/firewall/alias_schema.go
+++ b/internal/service/firewall/alias_schema.go
@@ -234,7 +234,11 @@ func convertAliasStructToSchema(d *firewall.Alias) (*aliasResourceModel, error) 
 		UpdateFreq:     types.Float64Value(tools.StringToFloat64(d.UpdateFreq)),
 		PathExpression: types.StringValue(d.PathExpression),
 		Statistics:     types.BoolValue(tools.StringToBool(d.Statistics)),
-		Description:    tools.StringOrNull(d.Description),
+	}
+	if d.Description != "" {
+		model.Description = types.StringValue(d.Description)
+	} else {
+		model.Description = types.StringNull()
 	}
 
 	// Parse 'IPProtocol'

--- a/internal/service/firewall/category_data_source.go
+++ b/internal/service/firewall/category_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &categoryDataSource{}
 var _ datasource.DataSourceWithConfigure = &categoryDataSource{}
 
-func newCategoryDataSource() datasource.DataSource {
-	return &categoryDataSource{}
-}
 
 // categoryDataSource defines the data source implementation.
 type categoryDataSource struct {

--- a/internal/service/firewall/category_resource.go
+++ b/internal/service/firewall/category_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &categoryResource{}
 var _ resource.ResourceWithConfigure = &categoryResource{}
 var _ resource.ResourceWithImportState = &categoryResource{}
 
-func newCategoryResource() resource.Resource {
-	return &categoryResource{}
-}
 
 // categoryResource defines the resource implementation.
 type categoryResource struct {

--- a/internal/service/firewall/exports.go
+++ b/internal/service/firewall/exports.go
@@ -9,22 +9,22 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newAliasResource,
-		newCategoryResource,
-		newFilterResource,
-		newNATResource,
-		newNATOneToOneResource,
-		newNATPortForwardResource,
+		func() resource.Resource { return &aliasResource{} },
+		func() resource.Resource { return &categoryResource{} },
+		func() resource.Resource { return &filterResource{} },
+		func() resource.Resource { return &natResource{} },
+		func() resource.Resource { return &natOneToOneResource{} },
+		func() resource.Resource { return &natPortForwardResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newAliasDataSource,
-		newCategoryDataSource,
-		newFilterDataSource,
-		newNATDataSource,
-		newNATOneToOneDataSource,
-		newNATPortForwardDataSource,
+		func() datasource.DataSource { return &aliasDataSource{} },
+		func() datasource.DataSource { return &categoryDataSource{} },
+		func() datasource.DataSource { return &filterDataSource{} },
+		func() datasource.DataSource { return &natDataSource{} },
+		func() datasource.DataSource { return &natOneToOneDataSource{} },
+		func() datasource.DataSource { return &natPortForwardDataSource{} },
 	}
 }

--- a/internal/service/firewall/filter_data_source.go
+++ b/internal/service/firewall/filter_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &filterDataSource{}
 var _ datasource.DataSourceWithConfigure = &filterDataSource{}
 
-func newFilterDataSource() datasource.DataSource {
-	return &filterDataSource{}
-}
 
 // filterDataSource defines the data source implementation.
 type filterDataSource struct {

--- a/internal/service/firewall/filter_resource.go
+++ b/internal/service/firewall/filter_resource.go
@@ -24,9 +24,6 @@ var _ resource.ResourceWithImportState = &filterResource{}
 var _ resource.ResourceWithConfigValidators = &filterResource{}
 var _ resource.ResourceWithUpgradeState = &filterResource{}
 
-func newFilterResource() resource.Resource {
-	return &filterResource{}
-}
 
 // filterResource defines the resource implementation.
 type filterResource struct {

--- a/internal/service/firewall/filter_schema.go
+++ b/internal/service/firewall/filter_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"sort"
+	"strconv"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/firewall"
@@ -1211,7 +1212,7 @@ func filterDataSourceSchema() dschema.Schema {
 func convertFilterSchemaToStruct(d *filterResourceModel) (*firewall.Filter, error) {
 	result := &firewall.Filter{
 		Enabled:      tools.BoolToString(d.Enabled.ValueBool()),
-		Sequence:     tools.Int64ToString(d.Sequence.ValueInt64()),
+		Sequence:     strconv.FormatInt(d.Sequence.ValueInt64(), 10),
 		NoXMLRPCSync: tools.BoolToString(d.NoXMLRPCSync.ValueBool()),
 		Description:  d.Description.ValueString(),
 	}
@@ -1344,7 +1345,11 @@ func convertFilterStructToSchema(d *firewall.Filter) (*filterResourceModel, erro
 		Enabled:      types.BoolValue(tools.StringToBool(d.Enabled)),
 		Sequence:     tools.StringToInt64Null(d.Sequence),
 		NoXMLRPCSync: types.BoolValue(tools.StringToBool(d.NoXMLRPCSync)),
-		Description:  tools.StringOrNull(d.Description),
+	}
+	if d.Description != "" {
+		model.Description = types.StringValue(d.Description)
+	} else {
+		model.Description = types.StringNull()
 	}
 
 	// Parse 'Categories'

--- a/internal/service/firewall/nat_data_source.go
+++ b/internal/service/firewall/nat_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &natDataSource{}
 var _ datasource.DataSourceWithConfigure = &natDataSource{}
 
-func newNATDataSource() datasource.DataSource {
-	return &natDataSource{}
-}
 
 // natDataSource defines the data source implementation.
 type natDataSource struct {

--- a/internal/service/firewall/nat_one_to_one_data_source.go
+++ b/internal/service/firewall/nat_one_to_one_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &natOneToOneDataSource{}
 var _ datasource.DataSourceWithConfigure = &natOneToOneDataSource{}
 
-func newNATOneToOneDataSource() datasource.DataSource {
-	return &natOneToOneDataSource{}
-}
 
 // natOneToOneDataSource defines the data source implementation.
 type natOneToOneDataSource struct {

--- a/internal/service/firewall/nat_one_to_one_resource.go
+++ b/internal/service/firewall/nat_one_to_one_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &natOneToOneResource{}
 var _ resource.ResourceWithConfigure = &natOneToOneResource{}
 var _ resource.ResourceWithImportState = &natOneToOneResource{}
 
-func newNATOneToOneResource() resource.Resource {
-	return &natOneToOneResource{}
-}
 
 // natOneToOneResource defines the resource implementation.
 type natOneToOneResource struct {

--- a/internal/service/firewall/nat_one_to_one_schema.go
+++ b/internal/service/firewall/nat_one_to_one_schema.go
@@ -3,6 +3,7 @@ package firewall
 import (
 	"context"
 	"regexp"
+	"strconv"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/firewall"
@@ -262,7 +263,7 @@ func convertNATOneToOneSchemaToStruct(d *natOneToOneResourceModel) (*firewall.Na
 
 	return &firewall.NatOneToOne{
 		Enabled:           tools.BoolToString(d.Enabled.ValueBool()),
-		Sequence:          tools.Int64ToString(d.Sequence.ValueInt64()),
+		Sequence:          strconv.FormatInt(d.Sequence.ValueInt64(), 10),
 		Interface:         api.SelectedMap(d.Interface.ValueString()),
 		Type:              api.SelectedMap(d.Type.ValueString()),
 		SourceNet:         d.Source.Net.ValueString(),
@@ -302,7 +303,11 @@ func convertNATOneToOneStructToSchema(d *firewall.NatOneToOne) (*natOneToOneReso
 		ExternalNet:   types.StringValue(d.ExternalNet),
 		NatReflection: types.StringValue(natReflection),
 		Categories:    types.SetNull(types.StringType),
-		Description:   tools.StringOrNull(d.Description),
+	}
+	if d.Description != "" {
+		model.Description = types.StringValue(d.Description)
+	} else {
+		model.Description = types.StringNull()
 	}
 
 	// Parse 'Categories'

--- a/internal/service/firewall/nat_port_forward_data_source.go
+++ b/internal/service/firewall/nat_port_forward_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &natPortForwardDataSource{}
 var _ datasource.DataSourceWithConfigure = &natPortForwardDataSource{}
 
-func newNATPortForwardDataSource() datasource.DataSource {
-	return &natPortForwardDataSource{}
-}
 
 // natPortForwardDataSource defines the data source implementation.
 type natPortForwardDataSource struct {

--- a/internal/service/firewall/nat_port_forward_resource.go
+++ b/internal/service/firewall/nat_port_forward_resource.go
@@ -20,9 +20,6 @@ var _ resource.ResourceWithConfigure = &natPortForwardResource{}
 var _ resource.ResourceWithImportState = &natPortForwardResource{}
 var _ resource.ResourceWithUpgradeState = &natPortForwardResource{}
 
-func newNATPortForwardResource() resource.Resource {
-	return &natPortForwardResource{}
-}
 
 // natPortForwardResource defines the resource implementation.
 type natPortForwardResource struct {

--- a/internal/service/firewall/nat_port_forward_schema.go
+++ b/internal/service/firewall/nat_port_forward_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
@@ -409,7 +410,7 @@ func convertNATPortForwardSchemaToStruct(d *natPortForwardResourceModel) (*firew
 	return &firewall.NatPortForward{
 		// Schema uses "enabled" (user-friendly), API uses "disabled" (inverted).
 		Disabled:   tools.BoolToString(!d.Enabled.ValueBool()),
-		Sequence:   tools.Int64ToString(d.Sequence.ValueInt64()),
+		Sequence:   strconv.FormatInt(d.Sequence.ValueInt64(), 10),
 		Interface:  natPortForwardInterfaceSchemaToAPI(d.Interface),
 		IPProtocol: api.SelectedMap(d.IPProtocol.ValueString()),
 		Protocol:   api.SelectedMap(d.Protocol.ValueString()),
@@ -441,7 +442,7 @@ func convertNATPortForwardStructToSchema(d *firewall.NatPortForward) (*natPortFo
 		destinationNet = "any"
 	}
 
-	return &natPortForwardResourceModel{
+	model := &natPortForwardResourceModel{
 		// API uses "disabled" (inverted), schema uses "enabled" (user-friendly).
 		Enabled:    types.BoolValue(!tools.StringToBool(d.Disabled)),
 		Sequence:   tools.StringToInt64Null(d.Sequence),
@@ -464,6 +465,11 @@ func convertNATPortForwardStructToSchema(d *firewall.NatPortForward) (*natPortFo
 		},
 		Log:           types.BoolValue(tools.StringToBool(d.Log)),
 		NatReflection: types.StringValue(natReflectionAPIToSchema(d.NatReflection.String())),
-		Description:   tools.StringOrNull(d.Description),
-	}, nil
+	}
+	if d.Description != "" {
+		model.Description = types.StringValue(d.Description)
+	} else {
+		model.Description = types.StringNull()
+	}
+	return model, nil
 }

--- a/internal/service/firewall/nat_resource.go
+++ b/internal/service/firewall/nat_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &natResource{}
 var _ resource.ResourceWithConfigure = &natResource{}
 var _ resource.ResourceWithImportState = &natResource{}
 
-func newNATResource() resource.Resource {
-	return &natResource{}
-}
 
 // natResource defines the resource implementation.
 type natResource struct {

--- a/internal/service/firewall/nat_schema.go
+++ b/internal/service/firewall/nat_schema.go
@@ -2,6 +2,7 @@ package firewall
 
 import (
 	"regexp"
+	"strconv"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/firewall"
@@ -313,7 +314,7 @@ func convertNATSchemaToStruct(d *natResourceModel) (*firewall.NAT, error) {
 	return &firewall.NAT{
 		Enabled:           tools.BoolToString(d.Enabled.ValueBool()),
 		DisableNAT:        tools.BoolToString(d.DisableNAT.ValueBool()),
-		Sequence:          tools.Int64ToString(d.Sequence.ValueInt64()),
+		Sequence:          strconv.FormatInt(d.Sequence.ValueInt64(), 10),
 		Interface:         api.SelectedMap(d.Interface.ValueString()),
 		IPProtocol:        api.SelectedMap(d.IPProtocol.ValueString()),
 		Protocol:          api.SelectedMap(d.Protocol.ValueString()),
@@ -331,7 +332,7 @@ func convertNATSchemaToStruct(d *natResourceModel) (*firewall.NAT, error) {
 }
 
 func convertNATStructToSchema(d *firewall.NAT) (*natResourceModel, error) {
-	return &natResourceModel{
+	model := &natResourceModel{
 		Enabled:    types.BoolValue(tools.StringToBool(d.Enabled)),
 		DisableNAT: types.BoolValue(tools.StringToBool(d.DisableNAT)),
 		Sequence:   tools.StringToInt64Null(d.Sequence),
@@ -352,7 +353,12 @@ func convertNATStructToSchema(d *firewall.NAT) (*natResourceModel, error) {
 			IP:   types.StringValue(d.Target),
 			Port: types.StringValue(d.TargetPort),
 		},
-		Log:         types.BoolValue(tools.StringToBool(d.Log)),
-		Description: tools.StringOrNull(d.Description),
-	}, nil
+		Log: types.BoolValue(tools.StringToBool(d.Log)),
+	}
+	if d.Description != "" {
+		model.Description = types.StringValue(d.Description)
+	} else {
+		model.Description = types.StringNull()
+	}
+	return model, nil
 }

--- a/internal/service/interfaces/exports.go
+++ b/internal/service/interfaces/exports.go
@@ -8,16 +8,16 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newVipResource,
-		newVlanResource,
+		func() resource.Resource { return &vipResource{} },
+		func() resource.Resource { return &vlanResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newVipDataSource,
-		newVlanDataSource,
-		newOverviewInterfaceDataSource,
-		newOverviewAllDataSource,
+		func() datasource.DataSource { return &vipDataSource{} },
+		func() datasource.DataSource { return &vlanDataSource{} },
+		func() datasource.DataSource { return &overviewInterfaceDataSource{} },
+		func() datasource.DataSource { return &overviewAllDataSource{} },
 	}
 }

--- a/internal/service/interfaces/overview_all_data_source.go
+++ b/internal/service/interfaces/overview_all_data_source.go
@@ -16,9 +16,6 @@ import (
 var _ datasource.DataSource = &overviewAllDataSource{}
 var _ datasource.DataSourceWithConfigure = &overviewAllDataSource{}
 
-func newOverviewAllDataSource() datasource.DataSource {
-	return &overviewAllDataSource{}
-}
 
 // overviewAllDataSource defines the data source implementation.
 type overviewAllDataSource struct {

--- a/internal/service/interfaces/overview_data_source.go
+++ b/internal/service/interfaces/overview_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &overviewInterfaceDataSource{}
 var _ datasource.DataSourceWithConfigure = &overviewInterfaceDataSource{}
 
-func newOverviewInterfaceDataSource() datasource.DataSource {
-	return &overviewInterfaceDataSource{}
-}
 
 // overviewInterfaceDataSource defines the data source implementation.
 type overviewInterfaceDataSource struct {

--- a/internal/service/interfaces/vip_data_source.go
+++ b/internal/service/interfaces/vip_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &vipDataSource{}
 var _ datasource.DataSourceWithConfigure = &vipDataSource{}
 
-func newVipDataSource() datasource.DataSource {
-	return &vipDataSource{}
-}
 
 // vipDataSource defines the data source implementation.
 type vipDataSource struct {

--- a/internal/service/interfaces/vip_resource.go
+++ b/internal/service/interfaces/vip_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &vipResource{}
 var _ resource.ResourceWithConfigure = &vipResource{}
 var _ resource.ResourceWithImportState = &vipResource{}
 
-func newVipResource() resource.Resource {
-	return &vipResource{}
-}
 
 // vipResource defines the resource implementation.
 type vipResource struct {

--- a/internal/service/interfaces/vip_schema.go
+++ b/internal/service/interfaces/vip_schema.go
@@ -3,7 +3,6 @@ package interfaces
 import (
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/interfaces"
-	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
 	"github.com/browningluke/terraform-provider-opnsense/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -118,11 +117,23 @@ func convertVipSchemaToStruct(d *vipResourceModel) (*interfaces.Vip, error) {
 }
 
 func convertVipStructToSchema(d *interfaces.Vip) (*vipResourceModel, error) {
+	var gateway types.String
+	if d.Gateway != "" {
+		gateway = types.StringValue(d.Gateway)
+	} else {
+		gateway = types.StringNull()
+	}
+	var description types.String
+	if d.Description != "" {
+		description = types.StringValue(d.Description)
+	} else {
+		description = types.StringNull()
+	}
 	return &vipResourceModel{
 		Mode:        types.StringValue(d.Mode.String()),
 		Interface:   types.StringValue(d.Interface.String()),
 		Network:     types.StringValue(d.Network),
-		Gateway:     tools.StringOrNull(d.Gateway),
-		Description: tools.StringOrNull(d.Description),
+		Gateway:     gateway,
+		Description: description,
 	}, nil
 }

--- a/internal/service/interfaces/vlan_data_source.go
+++ b/internal/service/interfaces/vlan_data_source.go
@@ -14,9 +14,6 @@ import (
 var _ datasource.DataSource = &vlanDataSource{}
 var _ datasource.DataSourceWithConfigure = &vlanDataSource{}
 
-func newVlanDataSource() datasource.DataSource {
-	return &vlanDataSource{}
-}
 
 // vlanDataSource defines the data source implementation.
 type vlanDataSource struct {

--- a/internal/service/interfaces/vlan_resource.go
+++ b/internal/service/interfaces/vlan_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &vlanResource{}
 var _ resource.ResourceWithConfigure = &vlanResource{}
 var _ resource.ResourceWithImportState = &vlanResource{}
 
-func newVlanResource() resource.Resource {
-	return &vlanResource{}
-}
 
 // vlanResource defines the resource implementation.
 type vlanResource struct {

--- a/internal/service/interfaces/vlan_schema.go
+++ b/internal/service/interfaces/vlan_schema.go
@@ -1,6 +1,8 @@
 package interfaces
 
 import (
+	"strconv"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/interfaces"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
@@ -111,8 +113,8 @@ func vlanDataSourceSchema() dschema.Schema {
 func convertVlanSchemaToStruct(d *vlanResourceModel) (*interfaces.Vlan, error) {
 	return &interfaces.Vlan{
 		Description: d.Description.ValueString(),
-		Tag:         tools.Int64ToString(d.Tag.ValueInt64()),
-		Priority:    api.SelectedMap(tools.Int64ToString(d.Priority.ValueInt64())),
+		Tag:         strconv.FormatInt(d.Tag.ValueInt64(), 10),
+		Priority:    api.SelectedMap(strconv.FormatInt(d.Priority.ValueInt64(), 10)),
 		Parent:      api.SelectedMap(d.Parent.ValueString()),
 		Device:      d.Device.ValueString(),
 	}, nil
@@ -127,8 +129,14 @@ func convertVlanStructToSchema(d *interfaces.Vlan) (*vlanResourceModel, error) {
 		priority = tools.StringToInt64(s)
 	}
 
+	var description types.String
+	if d.Description != "" {
+		description = types.StringValue(d.Description)
+	} else {
+		description = types.StringNull()
+	}
 	return &vlanResourceModel{
-		Description: tools.StringOrNull(d.Description),
+		Description: description,
 		Tag:         tools.StringToInt64Null(d.Tag),
 		Priority:    types.Int64Value(priority),
 		Parent:      types.StringValue(d.Parent.String()),

--- a/internal/service/ipsec/auth_local_resource.go
+++ b/internal/service/ipsec/auth_local_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &authLocalResource{}
 var _ resource.ResourceWithConfigure = &authLocalResource{}
 var _ resource.ResourceWithImportState = &authLocalResource{}
 
-func newAuthLocalResource() resource.Resource {
-	return &authLocalResource{}
-}
 
 // authLocalResource defines the resource implementation.
 type authLocalResource struct {

--- a/internal/service/ipsec/auth_remote_resource.go
+++ b/internal/service/ipsec/auth_remote_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &authRemoteResource{}
 var _ resource.ResourceWithConfigure = &authRemoteResource{}
 var _ resource.ResourceWithImportState = &authRemoteResource{}
 
-func newAuthRemoteResource() resource.Resource {
-	return &authRemoteResource{}
-}
 
 // authRemoteResource defines the resource implementation.
 type authRemoteResource struct {

--- a/internal/service/ipsec/child_resource.go
+++ b/internal/service/ipsec/child_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &childResource{}
 var _ resource.ResourceWithConfigure = &childResource{}
 var _ resource.ResourceWithImportState = &childResource{}
 
-func newChildResource() resource.Resource {
-	return &childResource{}
-}
 
 // childResource defines the resource implementation.
 type childResource struct {

--- a/internal/service/ipsec/connection_resource.go
+++ b/internal/service/ipsec/connection_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &connectionResource{}
 var _ resource.ResourceWithConfigure = &connectionResource{}
 var _ resource.ResourceWithImportState = &connectionResource{}
 
-func newConnectionResource() resource.Resource {
-	return &connectionResource{}
-}
 
 // connectionResource defines the resource implementation.
 type connectionResource struct {

--- a/internal/service/ipsec/exports.go
+++ b/internal/service/ipsec/exports.go
@@ -9,12 +9,12 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newAuthLocalResource,
-		newAuthRemoteResource,
-		newChildResource,
-		newConnectionResource,
-		newPskResource,
-		newVtiResource,
+		func() resource.Resource { return &authLocalResource{} },
+		func() resource.Resource { return &authRemoteResource{} },
+		func() resource.Resource { return &childResource{} },
+		func() resource.Resource { return &connectionResource{} },
+		func() resource.Resource { return &pskResource{} },
+		func() resource.Resource { return &vtiResource{} },
 	}
 }
 

--- a/internal/service/ipsec/psk_resource.go
+++ b/internal/service/ipsec/psk_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &pskResource{}
 var _ resource.ResourceWithConfigure = &pskResource{}
 var _ resource.ResourceWithImportState = &pskResource{}
 
-func newPskResource() resource.Resource {
-	return &pskResource{}
-}
 
 // pskResource defines the resource implementation.
 type pskResource struct {

--- a/internal/service/ipsec/psk_schema_test.go
+++ b/internal/service/ipsec/psk_schema_test.go
@@ -115,7 +115,7 @@ func TestConvertIpsecPskStructToSchema(t *testing.T) {
 			assert.Equal(t, tt.expected.IdentityRemote, result.IdentityRemote)
 			assert.Equal(t, tt.expected.PreSharedKey, result.PreSharedKey)
 			assert.Equal(t, tt.expected.Type, result.Type)
-			// Description comparison depends on tools.StringOrNull behavior
+			// Description is null when empty, non-null when set
 		})
 	}
 }

--- a/internal/service/ipsec/vti_resource.go
+++ b/internal/service/ipsec/vti_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &vtiResource{}
 var _ resource.ResourceWithConfigure = &vtiResource{}
 var _ resource.ResourceWithImportState = &vtiResource{}
 
-func newVtiResource() resource.Resource {
-	return &vtiResource{}
-}
 
 // vtiResource defines the resource implementation.
 type vtiResource struct {

--- a/internal/service/kea/dhcpv4_peer_data_source.go
+++ b/internal/service/kea/dhcpv4_peer_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &dhcpv4PeerDataSource{}
 var _ datasource.DataSourceWithConfigure = &dhcpv4PeerDataSource{}
 
-func newDhcpv4PeerDataSource() datasource.DataSource {
-	return &dhcpv4PeerDataSource{}
-}
 
 // dhcpv4PeerDataSource defines the data source implementation.
 type dhcpv4PeerDataSource struct {

--- a/internal/service/kea/dhcpv4_peer_resource.go
+++ b/internal/service/kea/dhcpv4_peer_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &dhcpv4PeerResource{}
 var _ resource.ResourceWithConfigure = &dhcpv4PeerResource{}
 var _ resource.ResourceWithImportState = &dhcpv4PeerResource{}
 
-func newDhcpv4PeerResource() resource.Resource {
-	return &dhcpv4PeerResource{}
-}
 
 // dhcpv4PeerResource defines the resource implementation.
 type dhcpv4PeerResource struct {

--- a/internal/service/kea/dhcpv4_reservation_data_source.go
+++ b/internal/service/kea/dhcpv4_reservation_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &dhcpv4ReservationDataSource{}
 var _ datasource.DataSourceWithConfigure = &dhcpv4ReservationDataSource{}
 
-func newDhcpv4ReservationDataSource() datasource.DataSource {
-	return &dhcpv4ReservationDataSource{}
-}
 
 // dhcpv4ReservationDataSource defines the data source implementation.
 type dhcpv4ReservationDataSource struct {

--- a/internal/service/kea/dhcpv4_reservation_resource.go
+++ b/internal/service/kea/dhcpv4_reservation_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &dhcpv4ReservationResource{}
 var _ resource.ResourceWithConfigure = &dhcpv4ReservationResource{}
 var _ resource.ResourceWithImportState = &dhcpv4ReservationResource{}
 
-func newDhcpv4ReservationResource() resource.Resource {
-	return &dhcpv4ReservationResource{}
-}
 
 // dhcpv4ReservationResource defines the resource implementation.
 type dhcpv4ReservationResource struct {

--- a/internal/service/kea/dhcpv4_subnet_data_source.go
+++ b/internal/service/kea/dhcpv4_subnet_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &dhcpv4SubnetDataSource{}
 var _ datasource.DataSourceWithConfigure = &dhcpv4SubnetDataSource{}
 
-func newDhcpv4SubnetDataSource() datasource.DataSource {
-	return &dhcpv4SubnetDataSource{}
-}
 
 // dhcpv4SubnetDataSource defines the data source implementation.
 type dhcpv4SubnetDataSource struct {

--- a/internal/service/kea/dhcpv4_subnet_resource.go
+++ b/internal/service/kea/dhcpv4_subnet_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &dhcpv4SubnetResource{}
 var _ resource.ResourceWithConfigure = &dhcpv4SubnetResource{}
 var _ resource.ResourceWithImportState = &dhcpv4SubnetResource{}
 
-func newDhcpv4SubnetResource() resource.Resource {
-	return &dhcpv4SubnetResource{}
-}
 
 // dhcpv4SubnetResource defines the resource implementation.
 type dhcpv4SubnetResource struct {

--- a/internal/service/kea/dhcpv4_subnet_schema.go
+++ b/internal/service/kea/dhcpv4_subnet_schema.go
@@ -274,10 +274,13 @@ func convertDhcpv4SubnetSchemaToStruct(d *dhcpv4SubnetResourceModel) (*kea.Subne
 			route.RouterIp.ValueString())
 	}
 
+	var poolsList []string
+	d.Pools.ElementsAs(context.Background(), &poolsList, false)
+
 	return &kea.SubnetV4{
 		Subnet:                d.Subnet.ValueString(),
 		NextServer:            d.NextServer.ValueString(),
-		Pools:                 tools.SetToString(d.Pools, "\n"),
+		Pools:                 strings.Join(poolsList, "\n"),
 		MatchClientId:         tools.BoolToString(d.MatchClientId.ValueBool()),
 		OptionDataAutoCollect: tools.BoolToString(d.AutoCollect.ValueBool()),
 		OptionData: kea.OptionDataV4{

--- a/internal/service/kea/dhcpv6_pd_pool_data_source.go
+++ b/internal/service/kea/dhcpv6_pd_pool_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &dhcpv6PdPoolDataSource{}
 var _ datasource.DataSourceWithConfigure = &dhcpv6PdPoolDataSource{}
 
-func newDhcpv6PdPoolDataSource() datasource.DataSource {
-	return &dhcpv6PdPoolDataSource{}
-}
 
 // dhcpv6PdPoolDataSource defines the data source implementation.
 type dhcpv6PdPoolDataSource struct {

--- a/internal/service/kea/dhcpv6_pd_pool_resource.go
+++ b/internal/service/kea/dhcpv6_pd_pool_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &dhcpv6PdPoolResource{}
 var _ resource.ResourceWithConfigure = &dhcpv6PdPoolResource{}
 var _ resource.ResourceWithImportState = &dhcpv6PdPoolResource{}
 
-func newDhcpv6PdPoolResource() resource.Resource {
-	return &dhcpv6PdPoolResource{}
-}
 
 // dhcpv6PdPoolResource defines the resource implementation.
 type dhcpv6PdPoolResource struct {

--- a/internal/service/kea/dhcpv6_peer_data_source.go
+++ b/internal/service/kea/dhcpv6_peer_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &dhcpv6PeerDataSource{}
 var _ datasource.DataSourceWithConfigure = &dhcpv6PeerDataSource{}
 
-func newDhcpv6PeerDataSource() datasource.DataSource {
-	return &dhcpv6PeerDataSource{}
-}
 
 // dhcpv6PeerDataSource defines the data source implementation.
 type dhcpv6PeerDataSource struct {

--- a/internal/service/kea/dhcpv6_peer_resource.go
+++ b/internal/service/kea/dhcpv6_peer_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &dhcpv6PeerResource{}
 var _ resource.ResourceWithConfigure = &dhcpv6PeerResource{}
 var _ resource.ResourceWithImportState = &dhcpv6PeerResource{}
 
-func newDhcpv6PeerResource() resource.Resource {
-	return &dhcpv6PeerResource{}
-}
 
 // dhcpv6PeerResource defines the resource implementation.
 type dhcpv6PeerResource struct {

--- a/internal/service/kea/dhcpv6_reservation_data_source.go
+++ b/internal/service/kea/dhcpv6_reservation_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &dhcpv6ReservationDataSource{}
 var _ datasource.DataSourceWithConfigure = &dhcpv6ReservationDataSource{}
 
-func newDhcpv6ReservationDataSource() datasource.DataSource {
-	return &dhcpv6ReservationDataSource{}
-}
 
 // dhcpv6ReservationDataSource defines the data source implementation.
 type dhcpv6ReservationDataSource struct {

--- a/internal/service/kea/dhcpv6_reservation_resource.go
+++ b/internal/service/kea/dhcpv6_reservation_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &dhcpv6ReservationResource{}
 var _ resource.ResourceWithConfigure = &dhcpv6ReservationResource{}
 var _ resource.ResourceWithImportState = &dhcpv6ReservationResource{}
 
-func newDhcpv6ReservationResource() resource.Resource {
-	return &dhcpv6ReservationResource{}
-}
 
 // dhcpv6ReservationResource defines the resource implementation.
 type dhcpv6ReservationResource struct {

--- a/internal/service/kea/dhcpv6_subnet_data_source.go
+++ b/internal/service/kea/dhcpv6_subnet_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &dhcpv6SubnetDataSource{}
 var _ datasource.DataSourceWithConfigure = &dhcpv6SubnetDataSource{}
 
-func newDhcpv6SubnetDataSource() datasource.DataSource {
-	return &dhcpv6SubnetDataSource{}
-}
 
 // dhcpv6SubnetDataSource defines the data source implementation.
 type dhcpv6SubnetDataSource struct {

--- a/internal/service/kea/dhcpv6_subnet_resource.go
+++ b/internal/service/kea/dhcpv6_subnet_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &dhcpv6SubnetResource{}
 var _ resource.ResourceWithConfigure = &dhcpv6SubnetResource{}
 var _ resource.ResourceWithImportState = &dhcpv6SubnetResource{}
 
-func newDhcpv6SubnetResource() resource.Resource {
-	return &dhcpv6SubnetResource{}
-}
 
 // dhcpv6SubnetResource defines the resource implementation.
 type dhcpv6SubnetResource struct {

--- a/internal/service/kea/dhcpv6_subnet_schema.go
+++ b/internal/service/kea/dhcpv6_subnet_schema.go
@@ -1,6 +1,7 @@
 package kea
 
 import (
+	"context"
 	"strings"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
@@ -145,11 +146,14 @@ func dhcpv6SubnetDataSourceSchema() dschema.Schema {
 }
 
 func convertDhcpv6SubnetSchemaToStruct(d *dhcpv6SubnetResourceModel) (*kea.SubnetV6, error) {
+	var poolsList []string
+	d.Pools.ElementsAs(context.Background(), &poolsList, false)
+
 	return &kea.SubnetV6{
 		Subnet:      d.Subnet.ValueString(),
 		Allocator:   api.SelectedMap(d.Allocator.ValueString()),
 		PDAllocator: api.SelectedMap(d.PDAllocator.ValueString()),
-		Pools:       tools.SetToString(d.Pools, "\n"),
+		Pools:       strings.Join(poolsList, "\n"),
 		Interface:   api.SelectedMap(d.Interface.ValueString()),
 		OptionData: kea.OptionDataV6{
 			DomainNameServers: tools.SetToStringSlice(d.DnsServers),

--- a/internal/service/kea/exports.go
+++ b/internal/service/kea/exports.go
@@ -10,35 +10,35 @@ import (
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		// Deprecated: use dhcpv4 variants
-		newPeerResource,
-		newReservationResource,
-		newSubnetResource,
+		func() resource.Resource { return &peerResource{} },
+		func() resource.Resource { return &reservationResource{} },
+		func() resource.Resource { return &subnetResource{} },
 		// DHCPv4
-		newDhcpv4PeerResource,
-		newDhcpv4ReservationResource,
-		newDhcpv4SubnetResource,
+		func() resource.Resource { return &dhcpv4PeerResource{} },
+		func() resource.Resource { return &dhcpv4ReservationResource{} },
+		func() resource.Resource { return &dhcpv4SubnetResource{} },
 		// DHCPv6
-		newDhcpv6PeerResource,
-		newDhcpv6ReservationResource,
-		newDhcpv6SubnetResource,
-		newDhcpv6PdPoolResource,
+		func() resource.Resource { return &dhcpv6PeerResource{} },
+		func() resource.Resource { return &dhcpv6ReservationResource{} },
+		func() resource.Resource { return &dhcpv6SubnetResource{} },
+		func() resource.Resource { return &dhcpv6PdPoolResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		// Deprecated: use dhcpv4 variants
-		newPeerDataSource,
-		newReservationDataSource,
-		newSubnetDataSource,
+		func() datasource.DataSource { return &peerDataSource{} },
+		func() datasource.DataSource { return &reservationDataSource{} },
+		func() datasource.DataSource { return &subnetDataSource{} },
 		// DHCPv4
-		newDhcpv4PeerDataSource,
-		newDhcpv4ReservationDataSource,
-		newDhcpv4SubnetDataSource,
+		func() datasource.DataSource { return &dhcpv4PeerDataSource{} },
+		func() datasource.DataSource { return &dhcpv4ReservationDataSource{} },
+		func() datasource.DataSource { return &dhcpv4SubnetDataSource{} },
 		// DHCPv6
-		newDhcpv6PeerDataSource,
-		newDhcpv6ReservationDataSource,
-		newDhcpv6SubnetDataSource,
-		newDhcpv6PdPoolDataSource,
+		func() datasource.DataSource { return &dhcpv6PeerDataSource{} },
+		func() datasource.DataSource { return &dhcpv6ReservationDataSource{} },
+		func() datasource.DataSource { return &dhcpv6SubnetDataSource{} },
+		func() datasource.DataSource { return &dhcpv6PdPoolDataSource{} },
 	}
 }

--- a/internal/service/kea/peer_data_source.go
+++ b/internal/service/kea/peer_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &peerDataSource{}
 var _ datasource.DataSourceWithConfigure = &peerDataSource{}
 
-func newPeerDataSource() datasource.DataSource {
-	return &peerDataSource{}
-}
 
 // peerDataSource defines the data source implementation.
 type peerDataSource struct {

--- a/internal/service/kea/peer_resource.go
+++ b/internal/service/kea/peer_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &peerResource{}
 var _ resource.ResourceWithConfigure = &peerResource{}
 var _ resource.ResourceWithImportState = &peerResource{}
 
-func newPeerResource() resource.Resource {
-	return &peerResource{}
-}
 
 // peerResource defines the resource implementation.
 type peerResource struct {

--- a/internal/service/kea/reservation_data_source.go
+++ b/internal/service/kea/reservation_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &reservationDataSource{}
 var _ datasource.DataSourceWithConfigure = &reservationDataSource{}
 
-func newReservationDataSource() datasource.DataSource {
-	return &reservationDataSource{}
-}
 
 // reservationDataSource defines the data source implementation.
 type reservationDataSource struct {

--- a/internal/service/kea/reservation_resource.go
+++ b/internal/service/kea/reservation_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &reservationResource{}
 var _ resource.ResourceWithConfigure = &reservationResource{}
 var _ resource.ResourceWithImportState = &reservationResource{}
 
-func newReservationResource() resource.Resource {
-	return &reservationResource{}
-}
 
 // reservationResource defines the resource implementation.
 type reservationResource struct {

--- a/internal/service/kea/subnet_data_source.go
+++ b/internal/service/kea/subnet_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &subnetDataSource{}
 var _ datasource.DataSourceWithConfigure = &subnetDataSource{}
 
-func newSubnetDataSource() datasource.DataSource {
-	return &subnetDataSource{}
-}
 
 // subnetDataSource defines the data source implementation.
 type subnetDataSource struct {

--- a/internal/service/kea/subnet_resource.go
+++ b/internal/service/kea/subnet_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &subnetResource{}
 var _ resource.ResourceWithConfigure = &subnetResource{}
 var _ resource.ResourceWithImportState = &subnetResource{}
 
-func newSubnetResource() resource.Resource {
-	return &subnetResource{}
-}
 
 // subnetResource defines the resource implementation.
 type subnetResource struct {

--- a/internal/service/kea/subnet_schema.go
+++ b/internal/service/kea/subnet_schema.go
@@ -294,10 +294,13 @@ func convertSubnetSchemaToStruct(d *subnetResourceModel) (*kea.SubnetV4, error) 
 			route.RouterIp.ValueString())
 	}
 
+	var poolsList []string
+	d.Pools.ElementsAs(context.Background(), &poolsList, false)
+
 	return &kea.SubnetV4{
 		Subnet:                d.Subnet.ValueString(),
 		NextServer:            d.NextServer.ValueString(),
-		Pools:                 tools.SetToString(d.Pools, "\n"),
+		Pools:                 strings.Join(poolsList, "\n"),
 		MatchClientId:         tools.BoolToString(d.MatchClientId.ValueBool()),
 		OptionDataAutoCollect: tools.BoolToString(d.AutoCollect.ValueBool()),
 		OptionData: kea.OptionDataV4{

--- a/internal/service/openvpn/client_overwrite_data_source.go
+++ b/internal/service/openvpn/client_overwrite_data_source.go
@@ -12,9 +12,6 @@ import (
 var _ datasource.DataSource = &clientOverwriteDataSource{}
 var _ datasource.DataSourceWithConfigure = &clientOverwriteDataSource{}
 
-func newClientOverwriteDataSource() datasource.DataSource {
-	return &clientOverwriteDataSource{}
-}
 
 type clientOverwriteDataSource struct {
 	client opnsense.Client

--- a/internal/service/openvpn/client_overwrite_resource.go
+++ b/internal/service/openvpn/client_overwrite_resource.go
@@ -18,9 +18,6 @@ var _ resource.Resource = &clientOverwriteResource{}
 var _ resource.ResourceWithConfigure = &clientOverwriteResource{}
 var _ resource.ResourceWithImportState = &clientOverwriteResource{}
 
-func newClientOverwriteResource() resource.Resource {
-	return &clientOverwriteResource{}
-}
 
 type clientOverwriteResource struct {
 	client opnsense.Client

--- a/internal/service/openvpn/exports.go
+++ b/internal/service/openvpn/exports.go
@@ -10,22 +10,22 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newInstanceResource,
-		newStaticKeyResource,
-		newClientOverwriteResource,
+		func() resource.Resource { return &instanceResource{} },
+		func() resource.Resource { return &staticKeyResource{} },
+		func() resource.Resource { return &clientOverwriteResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newInstanceDataSource,
-		newStaticKeyDataSource,
-		newClientOverwriteDataSource,
+		func() datasource.DataSource { return &instanceDataSource{} },
+		func() datasource.DataSource { return &staticKeyDataSource{} },
+		func() datasource.DataSource { return &clientOverwriteDataSource{} },
 	}
 }
 
 func EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {
 	return []func() ephemeral.EphemeralResource{
-		newGenerateKeyEphemeral,
+		func() ephemeral.EphemeralResource { return &generateKeyEphemeral{} },
 	}
 }

--- a/internal/service/openvpn/generate_key_ephemeral.go
+++ b/internal/service/openvpn/generate_key_ephemeral.go
@@ -16,9 +16,6 @@ import (
 var _ ephemeral.EphemeralResource = &generateKeyEphemeral{}
 var _ ephemeral.EphemeralResourceWithConfigure = &generateKeyEphemeral{}
 
-func newGenerateKeyEphemeral() ephemeral.EphemeralResource {
-	return &generateKeyEphemeral{}
-}
 
 type generateKeyEphemeral struct {
 	client opnsense.Client

--- a/internal/service/openvpn/instance_data_source.go
+++ b/internal/service/openvpn/instance_data_source.go
@@ -12,9 +12,6 @@ import (
 var _ datasource.DataSource = &instanceDataSource{}
 var _ datasource.DataSourceWithConfigure = &instanceDataSource{}
 
-func newInstanceDataSource() datasource.DataSource {
-	return &instanceDataSource{}
-}
 
 type instanceDataSource struct {
 	client opnsense.Client

--- a/internal/service/openvpn/instance_resource.go
+++ b/internal/service/openvpn/instance_resource.go
@@ -18,9 +18,6 @@ var _ resource.Resource = &instanceResource{}
 var _ resource.ResourceWithConfigure = &instanceResource{}
 var _ resource.ResourceWithImportState = &instanceResource{}
 
-func newInstanceResource() resource.Resource {
-	return &instanceResource{}
-}
 
 type instanceResource struct {
 	client opnsense.Client

--- a/internal/service/openvpn/static_key_data_source.go
+++ b/internal/service/openvpn/static_key_data_source.go
@@ -12,9 +12,6 @@ import (
 var _ datasource.DataSource = &staticKeyDataSource{}
 var _ datasource.DataSourceWithConfigure = &staticKeyDataSource{}
 
-func newStaticKeyDataSource() datasource.DataSource {
-	return &staticKeyDataSource{}
-}
 
 type staticKeyDataSource struct {
 	client opnsense.Client

--- a/internal/service/openvpn/static_key_resource.go
+++ b/internal/service/openvpn/static_key_resource.go
@@ -18,9 +18,6 @@ var _ resource.Resource = &staticKeyResource{}
 var _ resource.ResourceWithConfigure = &staticKeyResource{}
 var _ resource.ResourceWithImportState = &staticKeyResource{}
 
-func newStaticKeyResource() resource.Resource {
-	return &staticKeyResource{}
-}
 
 type staticKeyResource struct {
 	client opnsense.Client

--- a/internal/service/quagga/bgp_aspath_data_source.go
+++ b/internal/service/quagga/bgp_aspath_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &bgpASPathDataSource{}
 var _ datasource.DataSourceWithConfigure = &bgpASPathDataSource{}
 
-func newBGPASPathDataSource() datasource.DataSource {
-	return &bgpASPathDataSource{}
-}
 
 // bgpASPathDataSource defines the data source implementation.
 type bgpASPathDataSource struct {

--- a/internal/service/quagga/bgp_aspath_resource.go
+++ b/internal/service/quagga/bgp_aspath_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &bgpASPathResource{}
 var _ resource.ResourceWithConfigure = &bgpASPathResource{}
 var _ resource.ResourceWithImportState = &bgpASPathResource{}
 
-func newBGPASPathResource() resource.Resource {
-	return &bgpASPathResource{}
-}
 
 // bgpASPathResource defines the resource implementation.
 type bgpASPathResource struct {

--- a/internal/service/quagga/bgp_aspath_schema.go
+++ b/internal/service/quagga/bgp_aspath_schema.go
@@ -1,6 +1,8 @@
 package quagga
 
 import (
+	"strconv"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/quagga"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
@@ -112,7 +114,7 @@ func convertBGPASPathSchemaToStruct(d *bgpASPathResourceModel) (*quagga.BGPASPat
 	return &quagga.BGPASPath{
 		Enabled:     tools.BoolToString(d.Enabled.ValueBool()),
 		Description: d.Description.ValueString(),
-		Number:      tools.Int64ToString(d.Number.ValueInt64()),
+		Number:      strconv.FormatInt(d.Number.ValueInt64(), 10),
 		Action:      api.SelectedMap(d.Action.ValueString()),
 		AS:          d.AS.ValueString(),
 	}, nil

--- a/internal/service/quagga/bgp_communitylist_data_source.go
+++ b/internal/service/quagga/bgp_communitylist_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &bgpCommunityListDataSource{}
 var _ datasource.DataSourceWithConfigure = &bgpCommunityListDataSource{}
 
-func newBGPCommunityListDataSource() datasource.DataSource {
-	return &bgpCommunityListDataSource{}
-}
 
 // bgpCommunityListDataSource defines the data source implementation.
 type bgpCommunityListDataSource struct {

--- a/internal/service/quagga/bgp_communitylist_resource.go
+++ b/internal/service/quagga/bgp_communitylist_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &bgpCommunityListResource{}
 var _ resource.ResourceWithConfigure = &bgpCommunityListResource{}
 var _ resource.ResourceWithImportState = &bgpCommunityListResource{}
 
-func newBGPCommunityListResource() resource.Resource {
-	return &bgpCommunityListResource{}
-}
 
 // bgpCommunityListResource defines the resource implementation.
 type bgpCommunityListResource struct {

--- a/internal/service/quagga/bgp_communitylist_schema.go
+++ b/internal/service/quagga/bgp_communitylist_schema.go
@@ -1,6 +1,8 @@
 package quagga
 
 import (
+	"strconv"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/quagga"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
@@ -124,8 +126,8 @@ func convertBGPCommunityListSchemaToStruct(d *bgpCommunityListResourceModel) (*q
 	return &quagga.BGPCommunityList{
 		Enabled:        tools.BoolToString(d.Enabled.ValueBool()),
 		Description:    d.Description.ValueString(),
-		Number:         tools.Int64ToString(d.Number.ValueInt64()),
-		SequenceNumber: tools.Int64ToString(d.SequenceNumber.ValueInt64()),
+		Number:         strconv.FormatInt(d.Number.ValueInt64(), 10),
+		SequenceNumber: strconv.FormatInt(d.SequenceNumber.ValueInt64(), 10),
 		Action:         api.SelectedMap(d.Action.ValueString()),
 		Community:      d.Community.ValueString(),
 	}, nil

--- a/internal/service/quagga/bgp_neighbor_data_source.go
+++ b/internal/service/quagga/bgp_neighbor_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &bgpNeighborDataSource{}
 var _ datasource.DataSourceWithConfigure = &bgpNeighborDataSource{}
 
-func newBGPNeighborDataSource() datasource.DataSource {
-	return &bgpNeighborDataSource{}
-}
 
 // bgpNeighborDataSource defines the data source implementation.
 type bgpNeighborDataSource struct {

--- a/internal/service/quagga/bgp_neighbor_resource.go
+++ b/internal/service/quagga/bgp_neighbor_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &bgpNeighborResource{}
 var _ resource.ResourceWithConfigure = &bgpNeighborResource{}
 var _ resource.ResourceWithImportState = &bgpNeighborResource{}
 
-func newBGPNeighborResource() resource.Resource {
-	return &bgpNeighborResource{}
-}
 
 // bgpNeighborResource defines the resource implementation.
 type bgpNeighborResource struct {

--- a/internal/service/quagga/bgp_neighbor_schema.go
+++ b/internal/service/quagga/bgp_neighbor_schema.go
@@ -1,6 +1,8 @@
 package quagga
 
 import (
+	"strconv"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/quagga"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
@@ -341,7 +343,7 @@ func convertBGPNeighborSchemaToStruct(d *bgpNeighborResourceModel) (*quagga.BGPN
 		Enabled:               tools.BoolToString(d.Enabled.ValueBool()),
 		Description:           d.Description.ValueString(),
 		PeerIP:                d.PeerIP.ValueString(),
-		RemoteAS:              tools.Int64ToString(d.RemoteAS.ValueInt64()),
+		RemoteAS:              strconv.FormatInt(d.RemoteAS.ValueInt64(), 10),
 		Password:              d.Password.ValueString(),
 		Weight:                tools.Int64ToStringNegative(d.Weight.ValueInt64()),
 		LocalIP:               d.LocalIP.ValueString(),
@@ -353,8 +355,8 @@ func convertBGPNeighborSchemaToStruct(d *bgpNeighborResourceModel) (*quagga.BGPN
 		MultiProtocol:         tools.BoolToString(d.MultiProtocol.ValueBool()),
 		RRClient:              tools.BoolToString(d.RRClient.ValueBool()),
 		BFD:                   tools.BoolToString(d.BFD.ValueBool()),
-		KeepAlive:             tools.Int64ToString(d.KeepAlive.ValueInt64()),
-		HoldDown:              tools.Int64ToString(d.HoldDown.ValueInt64()),
+		KeepAlive:             strconv.FormatInt(d.KeepAlive.ValueInt64(), 10),
+		HoldDown:              strconv.FormatInt(d.HoldDown.ValueInt64(), 10),
 		ConnectTimer:          tools.Int64ToStringNegative(d.ConnectTimer.ValueInt64()),
 		DefaultRoute:          tools.BoolToString(d.DefaultRoute.ValueBool()),
 		ASOverride:            tools.BoolToString(d.ASOverride.ValueBool()),

--- a/internal/service/quagga/bgp_prefixlist_data_source.go
+++ b/internal/service/quagga/bgp_prefixlist_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &bgpPrefixListDataSource{}
 var _ datasource.DataSourceWithConfigure = &bgpPrefixListDataSource{}
 
-func newBGPPrefixListDataSource() datasource.DataSource {
-	return &bgpPrefixListDataSource{}
-}
 
 // bgpPrefixListDataSource defines the data source implementation.
 type bgpPrefixListDataSource struct {

--- a/internal/service/quagga/bgp_prefixlist_resource.go
+++ b/internal/service/quagga/bgp_prefixlist_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &bgpPrefixListResource{}
 var _ resource.ResourceWithConfigure = &bgpPrefixListResource{}
 var _ resource.ResourceWithImportState = &bgpPrefixListResource{}
 
-func newBGPPrefixListResource() resource.Resource {
-	return &bgpPrefixListResource{}
-}
 
 // bgpPrefixListResource defines the resource implementation.
 type bgpPrefixListResource struct {

--- a/internal/service/quagga/bgp_prefixlist_schema.go
+++ b/internal/service/quagga/bgp_prefixlist_schema.go
@@ -1,6 +1,8 @@
 package quagga
 
 import (
+	"strconv"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/quagga"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
@@ -137,7 +139,7 @@ func convertBGPPrefixListSchemaToStruct(d *bgpPrefixListResourceModel) (*quagga.
 		Description:    d.Description.ValueString(),
 		Name:           d.Name.ValueString(),
 		IPVersion:      api.SelectedMap(d.IPVersion.ValueString()),
-		SequenceNumber: tools.Int64ToString(d.Number.ValueInt64()),
+		SequenceNumber: strconv.FormatInt(d.Number.ValueInt64(), 10),
 		Action:         api.SelectedMap(d.Action.ValueString()),
 		Network:        d.Network.ValueString(),
 	}, nil

--- a/internal/service/quagga/bgp_routemap_data_source.go
+++ b/internal/service/quagga/bgp_routemap_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &bgpRouteMapDataSource{}
 var _ datasource.DataSourceWithConfigure = &bgpRouteMapDataSource{}
 
-func newBGPRouteMapDataSource() datasource.DataSource {
-	return &bgpRouteMapDataSource{}
-}
 
 // bgpRouteMapDataSource defines the data source implementation.
 type bgpRouteMapDataSource struct {

--- a/internal/service/quagga/bgp_routemap_resource.go
+++ b/internal/service/quagga/bgp_routemap_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &bgpRouteMapResource{}
 var _ resource.ResourceWithConfigure = &bgpRouteMapResource{}
 var _ resource.ResourceWithImportState = &bgpRouteMapResource{}
 
-func newBGPRouteMapResource() resource.Resource {
-	return &bgpRouteMapResource{}
-}
 
 // bgpRouteMapResource defines the resource implementation.
 type bgpRouteMapResource struct {

--- a/internal/service/quagga/bgp_routemap_schema.go
+++ b/internal/service/quagga/bgp_routemap_schema.go
@@ -2,6 +2,8 @@ package quagga
 
 import (
 	"context"
+	"strconv"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/quagga"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
@@ -178,7 +180,7 @@ func convertBGPRouteMapSchemaToStruct(d *bgpRouteMapResourceModel) (*quagga.BGPR
 		Description:   d.Description.ValueString(),
 		Name:          d.Name.ValueString(),
 		Action:        api.SelectedMap(d.Action.ValueString()),
-		RouteMapID:    tools.Int64ToString(d.RouteMapID.ValueInt64()),
+		RouteMapID:    strconv.FormatInt(d.RouteMapID.ValueInt64(), 10),
 		ASPathList:    asPathList,
 		PrefixList:    prefixList,
 		CommunityList: communityList,

--- a/internal/service/quagga/exports.go
+++ b/internal/service/quagga/exports.go
@@ -9,20 +9,20 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newBGPASPathResource,
-		newBGPCommunityListResource,
-		newBGPNeighborResource,
-		newBGPPrefixListResource,
-		newBGPRouteMapResource,
+		func() resource.Resource { return &bgpASPathResource{} },
+		func() resource.Resource { return &bgpCommunityListResource{} },
+		func() resource.Resource { return &bgpNeighborResource{} },
+		func() resource.Resource { return &bgpPrefixListResource{} },
+		func() resource.Resource { return &bgpRouteMapResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newBGPASPathDataSource,
-		newBGPCommunityListDataSource,
-		newBGPNeighborDataSource,
-		newBGPPrefixListDataSource,
-		newBGPRouteMapDataSource,
+		func() datasource.DataSource { return &bgpASPathDataSource{} },
+		func() datasource.DataSource { return &bgpCommunityListDataSource{} },
+		func() datasource.DataSource { return &bgpNeighborDataSource{} },
+		func() datasource.DataSource { return &bgpPrefixListDataSource{} },
+		func() datasource.DataSource { return &bgpRouteMapDataSource{} },
 	}
 }

--- a/internal/service/routes/exports.go
+++ b/internal/service/routes/exports.go
@@ -9,12 +9,12 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newRouteResource,
+		func() resource.Resource { return &routeResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newRouteDataSource,
+		func() datasource.DataSource { return &routeDataSource{} },
 	}
 }

--- a/internal/service/routes/route_data_source.go
+++ b/internal/service/routes/route_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &routeDataSource{}
 var _ datasource.DataSourceWithConfigure = &routeDataSource{}
 
-func newRouteDataSource() datasource.DataSource {
-	return &routeDataSource{}
-}
 
 // routeDataSource defines the data source implementation.
 type routeDataSource struct {

--- a/internal/service/routes/route_resource.go
+++ b/internal/service/routes/route_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &routeResource{}
 var _ resource.ResourceWithConfigure = &routeResource{}
 var _ resource.ResourceWithImportState = &routeResource{}
 
-func newRouteResource() resource.Resource {
-	return &routeResource{}
-}
 
 // routeResource defines the resource implementation.
 type routeResource struct {

--- a/internal/service/routes/route_schema.go
+++ b/internal/service/routes/route_schema.go
@@ -95,9 +95,15 @@ func convertRouteSchemaToStruct(d *routeResourceModel) (*routes.Route, error) {
 }
 
 func convertRouteStructToSchema(d *routes.Route) (*routeResourceModel, error) {
+	var description types.String
+	if d.Description != "" {
+		description = types.StringValue(d.Description)
+	} else {
+		description = types.StringNull()
+	}
 	return &routeResourceModel{
 		Enabled:     types.BoolValue(!tools.StringToBool(d.Disabled)),
-		Description: tools.StringOrNull(d.Description),
+		Description: description,
 		Gateway:     types.StringValue(d.Gateway.String()),
 		Network:     types.StringValue(d.Network),
 	}, nil

--- a/internal/service/trust/ca_data_source.go
+++ b/internal/service/trust/ca_data_source.go
@@ -14,9 +14,6 @@ import (
 var _ datasource.DataSource = &caDataSource{}
 var _ datasource.DataSourceWithConfigure = &caDataSource{}
 
-func newCaDataSource() datasource.DataSource {
-	return &caDataSource{}
-}
 
 type caDataSource struct {
 	client opnsense.Client

--- a/internal/service/trust/ca_resource.go
+++ b/internal/service/trust/ca_resource.go
@@ -18,9 +18,6 @@ var _ resource.Resource = &caResource{}
 var _ resource.ResourceWithConfigure = &caResource{}
 var _ resource.ResourceWithImportState = &caResource{}
 
-func newCaResource() resource.Resource {
-	return &caResource{}
-}
 
 type caResource struct {
 	client opnsense.Client

--- a/internal/service/trust/ca_schema.go
+++ b/internal/service/trust/ca_schema.go
@@ -3,7 +3,6 @@ package trust
 import (
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/trust"
-	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -326,13 +325,11 @@ func convertCaSchemaToStruct(d *caResourceModel) (*trust.Ca, error) {
 }
 
 func convertCaStructToSchema(d *trust.Ca) (*caResourceModel, error) {
-	return &caResourceModel{
-		RefId:              tools.StringOrNull(d.RefId),
+	model := &caResourceModel{
 		Description:        types.StringValue(d.Description),
 		Action:             types.StringValue(d.Action.String()),
 		Crt:                types.StringValue(d.Crt),
 		Prv:                types.StringValue(d.Prv),
-		Serial:             tools.StringOrNull(d.Serial),
 		CaRef:              types.StringValue(d.CaRef.String()),
 		KeyType:            types.StringValue(d.KeyType.String()),
 		Lifetime:           types.StringValue(d.Lifetime),
@@ -345,10 +342,41 @@ func convertCaStructToSchema(d *trust.Ca) (*caResourceModel, error) {
 		Email:              types.StringValue(d.Email),
 		CommonName:         types.StringValue(d.CommonName),
 		OcspUri:            types.StringValue(d.OcspUri),
-		CrtPayload:         tools.StringOrNull(d.CrtPayload),
-		PrvPayload:         tools.StringOrNull(d.PrvPayload),
-		Name:               tools.StringOrNull(d.Name),
-		ValidFrom:          tools.StringOrNull(d.ValidFrom),
-		ValidTo:            tools.StringOrNull(d.ValidTo),
-	}, nil
+	}
+	if d.RefId != "" {
+		model.RefId = types.StringValue(d.RefId)
+	} else {
+		model.RefId = types.StringNull()
+	}
+	if d.Serial != "" {
+		model.Serial = types.StringValue(d.Serial)
+	} else {
+		model.Serial = types.StringNull()
+	}
+	if d.CrtPayload != "" {
+		model.CrtPayload = types.StringValue(d.CrtPayload)
+	} else {
+		model.CrtPayload = types.StringNull()
+	}
+	if d.PrvPayload != "" {
+		model.PrvPayload = types.StringValue(d.PrvPayload)
+	} else {
+		model.PrvPayload = types.StringNull()
+	}
+	if d.Name != "" {
+		model.Name = types.StringValue(d.Name)
+	} else {
+		model.Name = types.StringNull()
+	}
+	if d.ValidFrom != "" {
+		model.ValidFrom = types.StringValue(d.ValidFrom)
+	} else {
+		model.ValidFrom = types.StringNull()
+	}
+	if d.ValidTo != "" {
+		model.ValidTo = types.StringValue(d.ValidTo)
+	} else {
+		model.ValidTo = types.StringNull()
+	}
+	return model, nil
 }

--- a/internal/service/trust/cert_data_source.go
+++ b/internal/service/trust/cert_data_source.go
@@ -14,9 +14,6 @@ import (
 var _ datasource.DataSource = &certDataSource{}
 var _ datasource.DataSourceWithConfigure = &certDataSource{}
 
-func newCertDataSource() datasource.DataSource {
-	return &certDataSource{}
-}
 
 type certDataSource struct {
 	client opnsense.Client

--- a/internal/service/trust/cert_resource.go
+++ b/internal/service/trust/cert_resource.go
@@ -18,9 +18,6 @@ var _ resource.Resource = &certResource{}
 var _ resource.ResourceWithConfigure = &certResource{}
 var _ resource.ResourceWithImportState = &certResource{}
 
-func newCertResource() resource.Resource {
-	return &certResource{}
-}
 
 type certResource struct {
 	client opnsense.Client

--- a/internal/service/trust/cert_schema.go
+++ b/internal/service/trust/cert_schema.go
@@ -3,7 +3,6 @@ package trust
 import (
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/trust"
-	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -419,8 +418,7 @@ func convertCertSchemaToStruct(d *certResourceModel) (*trust.Cert, error) {
 }
 
 func convertCertStructToSchema(d *trust.Cert) (*certResourceModel, error) {
-	return &certResourceModel{
-		RefId:              tools.StringOrNull(d.RefId),
+	model := &certResourceModel{
 		Description:        types.StringValue(d.Description),
 		CaRef:              types.StringValue(d.CaRef.String()),
 		Crt:                types.StringValue(d.Crt),
@@ -445,13 +443,51 @@ func convertCertStructToSchema(d *trust.Cert) (*certResourceModel, error) {
 		AltnamesUri:        types.StringValue(d.AltnamesUri),
 		AltnamesEmail:      types.StringValue(d.AltnamesEmail),
 		Rfc3280Purpose:     types.StringValue(d.Rfc3280Purpose),
-		InUse:              tools.StringOrNull(d.InUse),
-		IsUser:             tools.StringOrNull(d.IsUser),
-		CrtPayload:         tools.StringOrNull(d.CrtPayload),
-		CsrPayload:         tools.StringOrNull(d.CsrPayload),
-		PrvPayload:         tools.StringOrNull(d.PrvPayload),
-		Name:               tools.StringOrNull(d.Name),
-		ValidFrom:          tools.StringOrNull(d.ValidFrom),
-		ValidTo:            tools.StringOrNull(d.ValidTo),
-	}, nil
+	}
+	if d.RefId != "" {
+		model.RefId = types.StringValue(d.RefId)
+	} else {
+		model.RefId = types.StringNull()
+	}
+	if d.InUse != "" {
+		model.InUse = types.StringValue(d.InUse)
+	} else {
+		model.InUse = types.StringNull()
+	}
+	if d.IsUser != "" {
+		model.IsUser = types.StringValue(d.IsUser)
+	} else {
+		model.IsUser = types.StringNull()
+	}
+	if d.CrtPayload != "" {
+		model.CrtPayload = types.StringValue(d.CrtPayload)
+	} else {
+		model.CrtPayload = types.StringNull()
+	}
+	if d.CsrPayload != "" {
+		model.CsrPayload = types.StringValue(d.CsrPayload)
+	} else {
+		model.CsrPayload = types.StringNull()
+	}
+	if d.PrvPayload != "" {
+		model.PrvPayload = types.StringValue(d.PrvPayload)
+	} else {
+		model.PrvPayload = types.StringNull()
+	}
+	if d.Name != "" {
+		model.Name = types.StringValue(d.Name)
+	} else {
+		model.Name = types.StringNull()
+	}
+	if d.ValidFrom != "" {
+		model.ValidFrom = types.StringValue(d.ValidFrom)
+	} else {
+		model.ValidFrom = types.StringNull()
+	}
+	if d.ValidTo != "" {
+		model.ValidTo = types.StringValue(d.ValidTo)
+	} else {
+		model.ValidTo = types.StringNull()
+	}
+	return model, nil
 }

--- a/internal/service/trust/exports.go
+++ b/internal/service/trust/exports.go
@@ -9,16 +9,16 @@ import (
 
 func Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newCaResource,
-		newCertResource,
-		newSettingsResource,
+		func() resource.Resource { return &caResource{} },
+		func() resource.Resource { return &certResource{} },
+		func() resource.Resource { return &settingsResource{} },
 	}
 }
 
 func DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newCaDataSource,
-		newCertDataSource,
-		newSettingsDataSource,
+		func() datasource.DataSource { return &caDataSource{} },
+		func() datasource.DataSource { return &certDataSource{} },
+		func() datasource.DataSource { return &settingsDataSource{} },
 	}
 }

--- a/internal/service/trust/settings_data_source.go
+++ b/internal/service/trust/settings_data_source.go
@@ -14,9 +14,6 @@ import (
 var _ datasource.DataSource = &settingsDataSource{}
 var _ datasource.DataSourceWithConfigure = &settingsDataSource{}
 
-func newSettingsDataSource() datasource.DataSource {
-	return &settingsDataSource{}
-}
 
 type settingsDataSource struct {
 	client opnsense.Client

--- a/internal/service/trust/settings_resource.go
+++ b/internal/service/trust/settings_resource.go
@@ -15,9 +15,6 @@ var _ resource.Resource = &settingsResource{}
 var _ resource.ResourceWithConfigure = &settingsResource{}
 var _ resource.ResourceWithImportState = &settingsResource{}
 
-func newSettingsResource() resource.Resource {
-	return &settingsResource{}
-}
 
 type settingsResource struct {
 	client opnsense.Client

--- a/internal/service/unbound/acl_data_source.go
+++ b/internal/service/unbound/acl_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &aclDataSource{}
 var _ datasource.DataSourceWithConfigure = &aclDataSource{}
 
-func newAclDataSource() datasource.DataSource {
-	return &aclDataSource{}
-}
 
 // aclDataSource defines the data source implementation.
 type aclDataSource struct {

--- a/internal/service/unbound/acl_resource.go
+++ b/internal/service/unbound/acl_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &aclResource{}
 var _ resource.ResourceWithConfigure = &aclResource{}
 var _ resource.ResourceWithImportState = &aclResource{}
 
-func newAclResource() resource.Resource {
-	return &aclResource{}
-}
 
 // aclResource defines the resource implementation.
 type aclResource struct {

--- a/internal/service/unbound/acl_schema.go
+++ b/internal/service/unbound/acl_schema.go
@@ -130,11 +130,17 @@ func convertAclSchemaToStruct(d *aclResourceModel) (*unbound.Acl, error) {
 }
 
 func convertAclStructToSchema(d *unbound.Acl) (*aclResourceModel, error) {
+	var description types.String
+	if d.Description != "" {
+		description = types.StringValue(d.Description)
+	} else {
+		description = types.StringNull()
+	}
 	return &aclResourceModel{
 		Enabled:     types.BoolValue(tools.StringToBool(d.Enabled)),
 		Name:        types.StringValue(d.Name),
 		Action:      types.StringValue(d.Action.String()),
 		Networks:    tools.StringSliceToSet(d.Networks),
-		Description: tools.StringOrNull(d.Description),
+		Description: description,
 	}, nil
 }

--- a/internal/service/unbound/domain_override_data_source.go
+++ b/internal/service/unbound/domain_override_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &domainOverrideDataSource{}
 var _ datasource.DataSourceWithConfigure = &domainOverrideDataSource{}
 
-func newDomainOverrideDataSource() datasource.DataSource {
-	return &domainOverrideDataSource{}
-}
 
 // domainOverrideDataSource defines the data source implementation.
 type domainOverrideDataSource struct {

--- a/internal/service/unbound/domain_override_resource.go
+++ b/internal/service/unbound/domain_override_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &domainOverrideResource{}
 var _ resource.ResourceWithConfigure = &domainOverrideResource{}
 var _ resource.ResourceWithImportState = &domainOverrideResource{}
 
-func newDomainOverrideResource() resource.Resource {
-	return &domainOverrideResource{}
-}
 
 // domainOverrideResource defines the resource implementation.
 type domainOverrideResource struct {

--- a/internal/service/unbound/domain_override_schema.go
+++ b/internal/service/unbound/domain_override_schema.go
@@ -95,10 +95,16 @@ func convertDomainOverrideSchemaToStruct(d *domainOverrideResourceModel) (*unbou
 }
 
 func convertDomainOverrideStructToSchema(d *unbound.DomainOverride) (*domainOverrideResourceModel, error) {
+	var description types.String
+	if d.Description != "" {
+		description = types.StringValue(d.Description)
+	} else {
+		description = types.StringNull()
+	}
 	return &domainOverrideResourceModel{
 		Enabled:     types.BoolValue(tools.StringToBool(d.Enabled)),
 		Domain:      types.StringValue(d.Domain),
 		Server:      types.StringValue(d.Server),
-		Description: tools.StringOrNull(d.Description),
+		Description: description,
 	}, nil
 }

--- a/internal/service/unbound/exports.go
+++ b/internal/service/unbound/exports.go
@@ -9,22 +9,22 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newAclResource,
-		newDomainOverrideResource,
-		newForwardResource,
-		newHostAliasResource,
-		newHostOverrideResource,
-		newSettingsResource,
+		func() resource.Resource { return &aclResource{} },
+		func() resource.Resource { return &domainOverrideResource{} },
+		func() resource.Resource { return &forwardResource{} },
+		func() resource.Resource { return &hostAliasResource{} },
+		func() resource.Resource { return &hostOverrideResource{} },
+		func() resource.Resource { return &settingsResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newAclDataSource,
-		newDomainOverrideDataSource,
-		newForwardDataSource,
-		newHostAliasDataSource,
-		newHostOverrideDataSource,
-		newSettingsDataSource,
+		func() datasource.DataSource { return &aclDataSource{} },
+		func() datasource.DataSource { return &domainOverrideDataSource{} },
+		func() datasource.DataSource { return &forwardDataSource{} },
+		func() datasource.DataSource { return &hostAliasDataSource{} },
+		func() datasource.DataSource { return &hostOverrideDataSource{} },
+		func() datasource.DataSource { return &settingsDataSource{} },
 	}
 }

--- a/internal/service/unbound/forward_data_source.go
+++ b/internal/service/unbound/forward_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &forwardDataSource{}
 var _ datasource.DataSourceWithConfigure = &forwardDataSource{}
 
-func newForwardDataSource() datasource.DataSource {
-	return &forwardDataSource{}
-}
 
 // forwardDataSource defines the data source implementation.
 type forwardDataSource struct {

--- a/internal/service/unbound/forward_resource.go
+++ b/internal/service/unbound/forward_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &forwardResource{}
 var _ resource.ResourceWithConfigure = &forwardResource{}
 var _ resource.ResourceWithImportState = &forwardResource{}
 
-func newForwardResource() resource.Resource {
-	return &forwardResource{}
-}
 
 // forwardResource defines the resource implementation.
 type forwardResource struct {

--- a/internal/service/unbound/forward_schema.go
+++ b/internal/service/unbound/forward_schema.go
@@ -1,6 +1,8 @@
 package unbound
 
 import (
+	"strconv"
+
 	"github.com/browningluke/opnsense-go/pkg/unbound"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -104,7 +106,7 @@ func convertForwardSchemaToStruct(d *forwardResourceModel) (*unbound.Forward, er
 		Enabled:  tools.BoolToString(d.Enabled.ValueBool()),
 		Domain:   d.Domain.ValueString(),
 		Server:   d.ServerIP.ValueString(),
-		Port:     tools.Int64ToString(d.ServerPort.ValueInt64()),
+		Port:     strconv.FormatInt(d.ServerPort.ValueInt64(), 10),
 		VerifyCN: d.VerifyCN.ValueString(),
 	}, nil
 }

--- a/internal/service/unbound/host_alias_data_source.go
+++ b/internal/service/unbound/host_alias_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &hostAliasDataSource{}
 var _ datasource.DataSourceWithConfigure = &hostAliasDataSource{}
 
-func newHostAliasDataSource() datasource.DataSource {
-	return &hostAliasDataSource{}
-}
 
 // hostAliasDataSource defines the data source implementation.
 type hostAliasDataSource struct {

--- a/internal/service/unbound/host_alias_resource.go
+++ b/internal/service/unbound/host_alias_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &hostAliasResource{}
 var _ resource.ResourceWithConfigure = &hostAliasResource{}
 var _ resource.ResourceWithImportState = &hostAliasResource{}
 
-func newHostAliasResource() resource.Resource {
-	return &hostAliasResource{}
-}
 
 // hostAliasResource defines the resource implementation.
 type hostAliasResource struct {

--- a/internal/service/unbound/host_alias_schema.go
+++ b/internal/service/unbound/host_alias_schema.go
@@ -108,11 +108,17 @@ func convertHostAliasSchemaToStruct(d *hostAliasResourceModel) (*unbound.HostAli
 }
 
 func convertHostAliasStructToSchema(d *unbound.HostAlias) (*hostAliasResourceModel, error) {
+	var description types.String
+	if d.Description != "" {
+		description = types.StringValue(d.Description)
+	} else {
+		description = types.StringNull()
+	}
 	return &hostAliasResourceModel{
 		Enabled:     types.BoolValue(tools.StringToBool(d.Enabled)),
 		Hostname:    types.StringValue(d.Hostname),
 		Domain:      types.StringValue(d.Domain),
-		Description: tools.StringOrNull(d.Description),
+		Description: description,
 		Override:    types.StringValue(d.Host.String()),
 	}, nil
 }

--- a/internal/service/unbound/host_override_data_source.go
+++ b/internal/service/unbound/host_override_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &hostOverrideDataSource{}
 var _ datasource.DataSourceWithConfigure = &hostOverrideDataSource{}
 
-func newHostOverrideDataSource() datasource.DataSource {
-	return &hostOverrideDataSource{}
-}
 
 // hostOverrideDataSource defines the data source implementation.
 type hostOverrideDataSource struct {

--- a/internal/service/unbound/host_override_resource.go
+++ b/internal/service/unbound/host_override_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &hostOverrideResource{}
 var _ resource.ResourceWithConfigure = &hostOverrideResource{}
 var _ resource.ResourceWithImportState = &hostOverrideResource{}
 
-func newHostOverrideResource() resource.Resource {
-	return &hostOverrideResource{}
-}
 
 // hostOverrideResource defines the resource implementation.
 type hostOverrideResource struct {

--- a/internal/service/unbound/host_override_schema.go
+++ b/internal/service/unbound/host_override_schema.go
@@ -163,6 +163,12 @@ func convertHostOverrideSchemaToStruct(d *hostOverrideResourceModel) (*unbound.H
 }
 
 func convertHostOverrideStructToSchema(d *unbound.HostOverride) (*hostOverrideResourceModel, error) {
+	var description types.String
+	if d.Description != "" {
+		description = types.StringValue(d.Description)
+	} else {
+		description = types.StringNull()
+	}
 	return &hostOverrideResourceModel{
 		Enabled:     types.BoolValue(tools.StringToBool(d.Enabled)),
 		Hostname:    types.StringValue(d.Hostname),
@@ -171,6 +177,6 @@ func convertHostOverrideStructToSchema(d *unbound.HostOverride) (*hostOverrideRe
 		Server:      types.StringValue(d.Server),
 		MXPriority:  types.Int64Value(tools.StringToInt64(d.MXPriority)),
 		MXDomain:    types.StringValue(d.MXDomain),
-		Description: tools.StringOrNull(d.Description),
+		Description: description,
 	}, nil
 }

--- a/internal/service/unbound/settings_data_source.go
+++ b/internal/service/unbound/settings_data_source.go
@@ -14,9 +14,6 @@ import (
 var _ datasource.DataSource = &settingsDataSource{}
 var _ datasource.DataSourceWithConfigure = &settingsDataSource{}
 
-func newSettingsDataSource() datasource.DataSource {
-	return &settingsDataSource{}
-}
 
 // settingsDataSource defines the data source implementation.
 type settingsDataSource struct {

--- a/internal/service/unbound/settings_resource.go
+++ b/internal/service/unbound/settings_resource.go
@@ -17,9 +17,6 @@ var _ resource.Resource = &settingsResource{}
 var _ resource.ResourceWithConfigure = &settingsResource{}
 var _ resource.ResourceWithImportState = &settingsResource{}
 
-func newSettingsResource() resource.Resource {
-	return &settingsResource{}
-}
 
 // settingsResource defines the resource implementation.
 // This is a SINGLETON resource - it manages existing upstream configuration

--- a/internal/service/unbound/settings_schema.go
+++ b/internal/service/unbound/settings_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"sort"
+	"strconv"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
 	"github.com/browningluke/opnsense-go/pkg/unbound"
@@ -1300,7 +1301,7 @@ func convertSettingsSchemaToStruct(d *settingsResourceModel) (*unbound.Settings,
 	// Parse 'General' block
 	if d.General != nil {
 		result.General.Enabled = tools.BoolToString(d.General.Enabled.ValueBool())
-		result.General.Port = tools.Int64ToString(d.General.Port.ValueInt64())
+		result.General.Port = strconv.FormatInt(d.General.Port.ValueInt64(), 10)
 		result.General.DNSSEC = tools.BoolToString(d.General.EnableDNSSEC.ValueBool())
 		result.General.DNS64 = tools.BoolToString(d.General.EnableDNS64.ValueBool())
 		result.General.DNS64Prefix = d.General.DNS64Prefix.ValueString()

--- a/internal/service/wireguard/client_data_source.go
+++ b/internal/service/wireguard/client_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &clientDataSource{}
 var _ datasource.DataSourceWithConfigure = &clientDataSource{}
 
-func newClientDataSource() datasource.DataSource {
-	return &clientDataSource{}
-}
 
 // clientDataSource defines the data source implementation.
 type clientDataSource struct {

--- a/internal/service/wireguard/client_resource.go
+++ b/internal/service/wireguard/client_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &clientResource{}
 var _ resource.ResourceWithConfigure = &clientResource{}
 var _ resource.ResourceWithImportState = &clientResource{}
 
-func newClientResource() resource.Resource {
-	return &clientResource{}
-}
 
 // clientResource defines the resource implementation.
 type clientResource struct {

--- a/internal/service/wireguard/exports.go
+++ b/internal/service/wireguard/exports.go
@@ -9,16 +9,16 @@ import (
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newClientResource,
-		newServerResource,
-		newSettingsResource,
+		func() resource.Resource { return &clientResource{} },
+		func() resource.Resource { return &serverResource{} },
+		func() resource.Resource { return &settingsResource{} },
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newClientDataSource,
-		newServerDataSource,
-		newSettingsDataSource,
+		func() datasource.DataSource { return &clientDataSource{} },
+		func() datasource.DataSource { return &serverDataSource{} },
+		func() datasource.DataSource { return &settingsDataSource{} },
 	}
 }

--- a/internal/service/wireguard/server_data_source.go
+++ b/internal/service/wireguard/server_data_source.go
@@ -13,9 +13,6 @@ import (
 var _ datasource.DataSource = &serverDataSource{}
 var _ datasource.DataSourceWithConfigure = &serverDataSource{}
 
-func newServerDataSource() datasource.DataSource {
-	return &serverDataSource{}
-}
 
 // serverDataSource defines the data source implementation.
 type serverDataSource struct {

--- a/internal/service/wireguard/server_resource.go
+++ b/internal/service/wireguard/server_resource.go
@@ -19,9 +19,6 @@ var _ resource.Resource = &serverResource{}
 var _ resource.ResourceWithConfigure = &serverResource{}
 var _ resource.ResourceWithImportState = &serverResource{}
 
-func newServerResource() resource.Resource {
-	return &serverResource{}
-}
 
 // serverResource defines the resource implementation.
 type serverResource struct {

--- a/internal/service/wireguard/settings_data_source.go
+++ b/internal/service/wireguard/settings_data_source.go
@@ -15,9 +15,6 @@ import (
 var _ datasource.DataSource = &settingsDataSource{}
 var _ datasource.DataSourceWithConfigure = &settingsDataSource{}
 
-func newSettingsDataSource() datasource.DataSource {
-	return &settingsDataSource{}
-}
 
 type settingsDataSource struct {
 	client opnsense.Client

--- a/internal/service/wireguard/settings_resource.go
+++ b/internal/service/wireguard/settings_resource.go
@@ -16,9 +16,6 @@ var _ resource.Resource = &settingsResource{}
 var _ resource.ResourceWithConfigure = &settingsResource{}
 var _ resource.ResourceWithImportState = &settingsResource{}
 
-func newSettingsResource() resource.Resource {
-	return &settingsResource{}
-}
 
 // settingsResource defines the resource implementation.
 // This is a SINGLETON resource - it manages existing upstream configuration

--- a/internal/tools/type_utils.go
+++ b/internal/tools/type_utils.go
@@ -7,14 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"strconv"
-	"strings"
 )
 
 // Ints
-
-func Int64ToString(i int64) string {
-	return fmt.Sprintf("%d", i)
-}
 
 func StringToInt64(s string) int64 {
 	i, err := strconv.ParseInt(s, 10, 64)
@@ -76,16 +71,6 @@ func StringToBool(s string) bool {
 	return s == "1"
 }
 
-// Strings
-
-func StringOrNull(s string) types.String {
-	if s != "" {
-		return types.StringValue(s)
-	} else {
-		return types.StringNull()
-	}
-}
-
 // Sets
 
 func EmptySetValue(t attr.Type) types.Set {
@@ -110,12 +95,6 @@ func StringSliceToSet(s []string) basetypes.SetValue {
 	typeList, _ := types.SetValue(types.StringType, list)
 
 	return typeList
-}
-
-func SetToString(set types.Set, delim string) string {
-	var strList []string
-	set.ElementsAs(context.Background(), &strList, false)
-	return strings.Join(strList, delim)
 }
 
 func SetToStringSlice(set types.Set) []string {

--- a/internal/validators/description.go
+++ b/internal/validators/description.go
@@ -1,0 +1,18 @@
+package validators
+
+import "context"
+
+// descriptionValidator holds a static description string and satisfies the
+// Description / MarkdownDescription pair required by all Terraform validator
+// interfaces.  Embed it in any validator whose description is a fixed string.
+type descriptionValidator struct {
+	desc string
+}
+
+func (d descriptionValidator) Description(_ context.Context) string {
+	return d.desc
+}
+
+func (d descriptionValidator) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}

--- a/internal/validators/ip_cidr.go
+++ b/internal/validators/ip_cidr.go
@@ -7,14 +7,8 @@ import (
 	"regexp"
 )
 
-type ipOrCIDRValidator struct{}
-
-func (validator ipOrCIDRValidator) Description(_ context.Context) string {
-	return "must be a valid IPv4 or IPv6 address or CIDR (e.g. 192.168.0.1, 192.168.0.0/24, 2001:db8::1, 2001:db8::/64)"
-}
-
-func (validator ipOrCIDRValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
+type ipOrCIDRValidator struct {
+	descriptionValidator
 }
 
 func (validator ipOrCIDRValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
@@ -33,17 +27,13 @@ func (validator ipOrCIDRValidator) ValidateString(ctx context.Context, request v
 }
 
 func IpOrCIDR() validator.String {
-	return ipOrCIDRValidator{}
+	return ipOrCIDRValidator{
+		descriptionValidator{"must be a valid IPv4 or IPv6 address or CIDR (e.g. 192.168.0.1, 192.168.0.0/24, 2001:db8::1, 2001:db8::/64)"},
+	}
 }
 
-type cidrValidator struct{}
-
-func (validator cidrValidator) Description(_ context.Context) string {
-	return "must be a valid IPv4 or IPv6 CIDR (e.g. 192.168.0.0/24, 2001:db8::/64)"
-}
-
-func (validator cidrValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
+type cidrValidator struct {
+	descriptionValidator
 }
 
 func (validator cidrValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
@@ -62,5 +52,7 @@ func (validator cidrValidator) ValidateString(ctx context.Context, request valid
 }
 
 func CIDR() validator.String {
-	return cidrValidator{}
+	return cidrValidator{
+		descriptionValidator{"must be a valid IPv4 or IPv6 CIDR (e.g. 192.168.0.0/24, 2001:db8::/64)"},
+	}
 }

--- a/internal/validators/uuid.go
+++ b/internal/validators/uuid.go
@@ -8,14 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-type uuidv4Validator struct{}
-
-func (v uuidv4Validator) Description(_ context.Context) string {
-	return "must be a valid UUIDv4 (e.g. 1ae521bb-05e2-43c1-8e1f-7e34b53dc015)"
-}
-
-func (v uuidv4Validator) MarkdownDescription(ctx context.Context) string {
-	return v.Description(ctx)
+type uuidv4Validator struct {
+	descriptionValidator
 }
 
 func (v uuidv4Validator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
@@ -43,5 +37,7 @@ func (v uuidv4Validator) ValidateString(ctx context.Context, request validator.S
 }
 
 func IsUUIDv4() validator.String {
-	return uuidv4Validator{}
+	return uuidv4Validator{
+		descriptionValidator{"must be a valid UUIDv4 (e.g. 1ae521bb-05e2-43c1-8e1f-7e34b53dc015)"},
+	}
 }


### PR DESCRIPTION
## Description

Three internal refactors with no user-facing changes.

1. **`internal/validators/`** — extract shared `Description`/`MarkdownDescription` boilerplate into an embedded `descriptionValidator` struct; applied to `uuid.go` and `ip_cidr.go` (dynamic-description validators left as-is).

2. **`internal/tools/type_utils.go`** — remove wrappers that duplicated stdlib (`Int64ToString` → `strconv.FormatInt`, `StringOrNull` inlined, `SetToString` → `strings.Join`); update ~30 callsites. Domain-specific helpers (`BoolToString`, `StringToInt64`, `Int64ToStringNegative`, etc.) kept.

3. **`internal/service/*/exports.go`** — inline 91 trivial factory functions (`func newXxxResource() resource.Resource { return &xxxResource{} }`) that had exactly one caller. Net −273 lines across 103 files.

## Related Issues

N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)

N/A — purely internal refactor.

## Schema Changes (if applicable)

N/A

## Testing
- [ ] Unit tests added/updated (optional, but encouraged)
- [x] Acceptance tests added/updated (mandatory)

No logic changes — existing acceptance tests cover all affected code paths.

## Examples
- [x] N/A - No user-facing changes

## Environment

N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been generated (`make docs`)
- [x] Code has been formatted (`make fmt`)
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [ ] Tests pass locally & in test workflow