### PR TITLE
ci: fail image build when OPNsense patch level drifts from expected

### DIFF
--- a/.github/workflows/build-opnsense-image-reusable.yml
+++ b/.github/workflows/build-opnsense-image-reusable.yml
@@ -8,6 +8,12 @@ permissions:
 
 env:
   OPNSENSE_VERSION: "26.1"
+  # Patch level the image is expected to land on after the upgrade step.
+  # pkg only serves the latest 26.1.x, so this acts as a tripwire: when
+  # OPNsense releases a new patch, the image build fails until this value
+  # is bumped — making version changes explicit instead of depending on
+  # when the image cache happens to be evicted and rebuilt.
+  OPNSENSE_TARGET_PATCH: "26.1.11"
   OPNSENSE_URL: "https://files.bsd.ac/opnsense-qemu/opnsense-26.1.qcow2"
   OPNSENSE_SHA1: 2266a644b1669be1a8d916a0a79fc91ba4be4733
   OPNSENSE_SSH_PORT: 8022
@@ -24,7 +30,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: opnsense-images
-          key: opnsense-image-${{ env.OPNSENSE_SHA1 }}-${{ hashFiles('scripts/upgrade-opnsense.py') }}
+          key: opnsense-image-${{ env.OPNSENSE_SHA1 }}-${{ env.OPNSENSE_TARGET_PATCH }}-${{ hashFiles('scripts/upgrade-opnsense.py') }}
       - name: Create opnsense image directory
         if: steps.cache.outputs.cache-hit != 'true'
         run: mkdir -p opnsense-images
@@ -72,6 +78,7 @@ jobs:
         # The bsd.ac image ships OPNsense 26.1 base. Multiple DNAT bugs
         # were fixed in 26.1.1-26.1.3 (community changelog) that cause
         # /api/firewall/d_nat/addRule to return 500. Apply patches first.
+        # Fails if the resulting version != OPNSENSE_TARGET_PATCH.
         run: python3 scripts/upgrade-opnsense.py
       - name: Shutdown OPNsense VM
         if: steps.cache.outputs.cache-hit != 'true'

--- a/scripts/upgrade-opnsense.py
+++ b/scripts/upgrade-opnsense.py
@@ -116,6 +116,15 @@ def main():
     code, out, _ = guest_exec("/usr/local/sbin/opnsense-version", [], max_wait_s=20)
     print(f"opnsense-version exit={code} output={out.strip()}")
 
+    target = os.environ.get("OPNSENSE_TARGET_PATCH")
+    if target and target not in out:
+        sys.exit(
+            f"upgraded to {out.strip()!r} but expected {target}. "
+            "OPNsense released a new patch: verify the test suite against it, "
+            "then bump OPNSENSE_TARGET_PATCH in "
+            ".github/workflows/build-opnsense-image-reusable.yml."
+        )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Description
The CI OPNsense image is upgraded to whatever 26.1.x patch the pkg mirror serves at build time, and the `Build OPNsense Image` cron **deletes and rebuilds the image cache every 7 days** — so the OPNsense version under test changes silently, with no diff in this repo. That's how the June 29/July 1 rebuilds moved CI from 26.1.9 to 26.1.10 and broke the routes suite (see #156): the cache key stayed identical, every run still logged "cache hit", but the image content had changed.

This makes version drift explicit:
- `OPNSENSE_TARGET_PATCH` (currently `26.1.11`, what the mirror serves today — verified via `pkg rquery` against a live VM) declares the expected patch level.
- The value is part of the image cache key, so bumping it forces a rebuild.
- `upgrade-opnsense.py` fails the image build if the upgraded version doesn't match, with a message telling the operator to validate the new patch and bump the value.

When OPNsense ships 26.1.12, the weekly rebuild fails loudly instead of silently switching versions mid-week; the fix is a one-line reviewed bump (which triggers a full validation run via the tiers).

## Related Issues
Companion to #156 (the regression this would have caught) and #154/#155.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Breaking Changes (if applicable)
N/A

## Schema Changes (if applicable)
- [ ] Schema `Version` incremented
- [ ] `UpgradeState` function implemented
- [x] Or: v0 exception applies (explain why below)

**Explanation**: CI-only change.

## Testing
- [ ] Unit tests added/updated (optional, but encouraged)
- [ ] Acceptance tests added/updated (mandatory)

CI-only. Python syntax and workflow validated (actionlint 1.7.12). Mirror version confirmed as 26.1.11_5 today, so the first rebuild under the new key passes the tripwire. Full validation: dispatch Tier 3 after this merges together with #154/#155/#156 — the new cache key forces a clean 26.1.11 image build, and the suite runs against it. Note the first build after merge takes the ~20 min uncached path.

## Examples
- [x] N/A - No user-facing changes

## Environment
- **OPNsense version tested**: 26.1.10 (current CI image), mirror serving 26.1.11_5
- **Terraform version**: N/A

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation has been generated (`make docs`) — N/A
- [ ] Code has been formatted (`make fmt`) — N/A
- [x] Supporting code has been merged and _released_ in [browningluke/opnsense-go](https://github.com/browningluke/opnsense-go)
- [ ] Tests pass locally & in test workflow
