### PR TITLE
feat(kea): add per-subnet valid lifetime

### DIFF
--- a/docs/data-sources/kea_dhcpv4_subnet.md
+++ b/docs/data-sources/kea_dhcpv4_subnet.md
@@ -41,6 +41,7 @@ data "opnsense_kea_dhcpv4_subnet" "example" {
 - `tftp_bootfile` (String) Boot filename to request.
 - `tftp_server` (String) TFTP server address or fqdn.
 - `time_servers` (Set of String) Set of RFC 868 time servers available to the client.
+- `valid_lifetime` (Number) Valid lifetime for leases in this subnet, in seconds.
 
 <a id="nestedatt--static_routes"></a>
 ### Nested Schema for `static_routes`

--- a/docs/resources/kea_dhcpv4_subnet.md
+++ b/docs/resources/kea_dhcpv4_subnet.md
@@ -102,6 +102,7 @@ resource "opnsense_kea_dhcpv4_subnet" "example" {
 - `tftp_bootfile` (String) Boot filename to request. Defaults to `""`.
 - `tftp_server` (String) TFTP server address or fqdn. Defaults to `""`.
 - `time_servers` (Set of String) Set of RFC 868 time servers available to the client. Defaults to `[]`.
+- `valid_lifetime` (Number) Valid lifetime for leases in this subnet, in seconds. When omitted, the global Kea DHCPv4 valid lifetime is inherited.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -88,3 +88,5 @@ require (
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/browningluke/opnsense-go => github.com/stoffus/opnsense-go v0.18.1-0.20260821084035-8b2bf3c347d9

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/browningluke/opnsense-go v0.25.0 h1:OQ+DOmHszW0yewHx+FHqDwS4wUwAUJ4bd0/cEM8Bht4=
-github.com/browningluke/opnsense-go v0.25.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -189,6 +187,8 @@ github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQ
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
+github.com/stoffus/opnsense-go v0.18.1-0.20260821084035-8b2bf3c347d9 h1:57xUhe0lXLlrx35JQxA67nX0jmBu29CHXj16wtrAHCo=
+github.com/stoffus/opnsense-go v0.18.1-0.20260821084035-8b2bf3c347d9/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/service/kea/dhcpv4_subnet_resource.go
+++ b/internal/service/kea/dhcpv4_subnet_resource.go
@@ -18,6 +18,7 @@ import (
 var _ resource.Resource = &dhcpv4SubnetResource{}
 var _ resource.ResourceWithConfigure = &dhcpv4SubnetResource{}
 var _ resource.ResourceWithImportState = &dhcpv4SubnetResource{}
+var _ resource.ResourceWithUpgradeState = &dhcpv4SubnetResource{}
 
 func newDhcpv4SubnetResource() resource.Resource {
 	return &dhcpv4SubnetResource{}
@@ -171,4 +172,41 @@ func (r *dhcpv4SubnetResource) Delete(ctx context.Context, req resource.DeleteRe
 
 func (r *dhcpv4SubnetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *dhcpv4SubnetResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := dhcpv4SubnetResourceSchemaV0()
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaV0,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var oldState dhcpv4SubnetResourceModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &oldState)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				newState := &dhcpv4SubnetResourceModel{
+					Subnet:            oldState.Subnet,
+					Pools:             oldState.Pools,
+					ValidLifetime:     types.Int64Null(),
+					MatchClientId:     oldState.MatchClientId,
+					AutoCollect:       oldState.AutoCollect,
+					Routers:           oldState.Routers,
+					StaticRoutes:      oldState.StaticRoutes,
+					DomainNameServers: oldState.DomainNameServers,
+					DomainName:        oldState.DomainName,
+					DomainSearch:      oldState.DomainSearch,
+					NTPServers:        oldState.NTPServers,
+					TimeServers:       oldState.TimeServers,
+					NextServer:        oldState.NextServer,
+					TFTPServer:        oldState.TFTPServer,
+					TFTPBootfile:      oldState.TFTPBootfile,
+					Description:       oldState.Description,
+					Id:                oldState.Id,
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+			},
+		},
+	}
 }

--- a/internal/service/kea/dhcpv4_subnet_resource_test.go
+++ b/internal/service/kea/dhcpv4_subnet_resource_test.go
@@ -18,6 +18,7 @@ func TestAccKeaDhcpv4SubnetResource(t *testing.T) {
 				Config: testAccDhcpv4SubnetResourceConfig(
 					"192.168.200.0/24",
 					"192.168.200.100 - 192.168.200.200",
+					86400,
 					false,
 					"192.168.200.1",
 					"8.8.8.8",
@@ -27,6 +28,7 @@ func TestAccKeaDhcpv4SubnetResource(t *testing.T) {
 					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "subnet", "192.168.200.0/24"),
 					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "pools.#", "1"),
 					resource.TestCheckTypeSetElemAttr("opnsense_kea_dhcpv4_subnet.test", "pools.*", "192.168.200.100 - 192.168.200.200"),
+					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "valid_lifetime", "86400"),
 					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "match_client_id", "true"),
 					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "auto_collect", "false"),
 					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "routers.#", "1"),
@@ -48,6 +50,7 @@ func TestAccKeaDhcpv4SubnetResource(t *testing.T) {
 				Config: testAccDhcpv4SubnetResourceConfig(
 					"192.168.200.0/24",
 					"192.168.200.100 - 192.168.200.150",
+					43200,
 					false,
 					"192.168.200.1",
 					"8.8.8.8",
@@ -56,6 +59,7 @@ func TestAccKeaDhcpv4SubnetResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "pools.#", "1"),
 					resource.TestCheckTypeSetElemAttr("opnsense_kea_dhcpv4_subnet.test", "pools.*", "192.168.200.100 - 192.168.200.150"),
+					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "valid_lifetime", "43200"),
 					resource.TestCheckResourceAttr("opnsense_kea_dhcpv4_subnet.test", "description", "Test Kea DHCPv4 Subnet Updated"),
 				),
 			},
@@ -64,15 +68,16 @@ func TestAccKeaDhcpv4SubnetResource(t *testing.T) {
 	})
 }
 
-func testAccDhcpv4SubnetResourceConfig(subnet, pool string, autoCollect bool, router, dns, description string) string {
+func testAccDhcpv4SubnetResourceConfig(subnet, pool string, validLifetime int, autoCollect bool, router, dns, description string) string {
 	return fmt.Sprintf(`
 resource "opnsense_kea_dhcpv4_subnet" "test" {
-  subnet       = %[1]q
-  pools        = [%[2]q]
-  auto_collect = %[3]t
-  routers      = [%[4]q]
-  dns_servers  = [%[5]q]
-  description  = %[6]q
+  subnet         = %[1]q
+  pools          = [%[2]q]
+  valid_lifetime = %[3]d
+  auto_collect   = %[4]t
+  routers        = [%[5]q]
+  dns_servers    = [%[6]q]
+  description    = %[7]q
 }
-`, subnet, pool, autoCollect, router, dns, description)
+`, subnet, pool, validLifetime, autoCollect, router, dns, description)
 }

--- a/internal/service/kea/dhcpv4_subnet_schema.go
+++ b/internal/service/kea/dhcpv4_subnet_schema.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/browningluke/opnsense-go/pkg/kea"
 	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -21,6 +23,8 @@ import (
 type dhcpv4SubnetResourceModel struct {
 	Subnet types.String `tfsdk:"subnet"`
 	Pools  types.Set    `tfsdk:"pools"`
+
+	ValidLifetime types.Int64 `tfsdk:"valid_lifetime"`
 
 	MatchClientId types.Bool `tfsdk:"match_client_id"`
 
@@ -48,6 +52,7 @@ type dhcpv4SubnetResourceModel struct {
 func dhcpv4SubnetResourceSchema() schema.Schema {
 	return schema.Schema{
 		MarkdownDescription: "Configure DHCPv4 subnets for Kea.",
+		Version:             1,
 
 		Attributes: map[string]schema.Attribute{
 			"subnet": schema.StringAttribute{
@@ -60,6 +65,13 @@ func dhcpv4SubnetResourceSchema() schema.Schema {
 				Computed:            true,
 				ElementType:         types.StringType,
 				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"valid_lifetime": schema.Int64Attribute{
+				MarkdownDescription: "Valid lifetime for leases in this subnet, in seconds. When omitted, the global Kea DHCPv4 valid lifetime is inherited.",
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 			},
 			"match_client_id": schema.BoolAttribute{
 				MarkdownDescription: "By default, KEA uses client-identifiers instead of MAC addresses to locate clients, disabling this option changes back to matching on MAC address which is used by most dhcp implementations. Defaults to `true`.",
@@ -191,6 +203,10 @@ func dhcpv4SubnetDataSourceSchema() dschema.Schema {
 				Computed:            true,
 				ElementType:         types.StringType,
 			},
+			"valid_lifetime": dschema.Int64Attribute{
+				MarkdownDescription: "Valid lifetime for leases in this subnet, in seconds.",
+				Computed:            true,
+			},
 			"match_client_id": dschema.BoolAttribute{
 				MarkdownDescription: "Whether to match on client-identifier.",
 				Computed:            true,
@@ -274,8 +290,14 @@ func convertDhcpv4SubnetSchemaToStruct(d *dhcpv4SubnetResourceModel) (*kea.Subne
 			route.RouterIp.ValueString())
 	}
 
+	validLifetime := ""
+	if !d.ValidLifetime.IsNull() && !d.ValidLifetime.IsUnknown() {
+		validLifetime = tools.Int64ToString(d.ValidLifetime.ValueInt64())
+	}
+
 	return &kea.SubnetV4{
 		Subnet:                d.Subnet.ValueString(),
+		ValidLifetime:         validLifetime,
 		NextServer:            d.NextServer.ValueString(),
 		Pools:                 tools.SetToString(d.Pools, "\n"),
 		MatchClientId:         tools.BoolToString(d.MatchClientId.ValueBool()),
@@ -299,6 +321,7 @@ func convertDhcpv4SubnetStructToSchema(d *kea.SubnetV4) (*dhcpv4SubnetResourceMo
 	model := &dhcpv4SubnetResourceModel{
 		Subnet:            types.StringValue(d.Subnet),
 		Pools:             tools.StringSliceToSet(strings.Split(d.Pools, "\n")),
+		ValidLifetime:     tools.StringToInt64Null(d.ValidLifetime),
 		MatchClientId:     types.BoolValue(tools.StringToBool(d.MatchClientId)),
 		AutoCollect:       types.BoolValue(tools.StringToBool(d.OptionDataAutoCollect)),
 		Routers:           tools.StringSliceToSet(d.OptionData.Routers),
@@ -346,4 +369,37 @@ func convertDhcpv4SubnetStructToSchema(d *kea.SubnetV4) (*dhcpv4SubnetResourceMo
 	model.StaticRoutes = v
 
 	return model, nil
+}
+
+// dhcpv4SubnetResourceModelV0 describes the resource state before valid_lifetime was added.
+type dhcpv4SubnetResourceModelV0 struct {
+	Subnet types.String `tfsdk:"subnet"`
+	Pools  types.Set    `tfsdk:"pools"`
+
+	MatchClientId types.Bool `tfsdk:"match_client_id"`
+	AutoCollect   types.Bool `tfsdk:"auto_collect"`
+
+	Routers      types.Set `tfsdk:"routers"`
+	StaticRoutes types.Set `tfsdk:"static_routes"`
+
+	DomainNameServers types.Set    `tfsdk:"dns_servers"`
+	DomainName        types.String `tfsdk:"domain_name"`
+	DomainSearch      types.Set    `tfsdk:"domain_search"`
+
+	NTPServers  types.Set `tfsdk:"ntp_servers"`
+	TimeServers types.Set `tfsdk:"time_servers"`
+
+	NextServer   types.String `tfsdk:"next_server"`
+	TFTPServer   types.String `tfsdk:"tftp_server"`
+	TFTPBootfile types.String `tfsdk:"tftp_bootfile"`
+
+	Description types.String `tfsdk:"description"`
+	Id          types.String `tfsdk:"id"`
+}
+
+func dhcpv4SubnetResourceSchemaV0() schema.Schema {
+	previous := dhcpv4SubnetResourceSchema()
+	previous.Version = 0
+	delete(previous.Attributes, "valid_lifetime")
+	return previous
 }

--- a/internal/service/kea/dhcpv4_subnet_schema_test.go
+++ b/internal/service/kea/dhcpv4_subnet_schema_test.go
@@ -1,0 +1,38 @@
+package kea
+
+import (
+	"testing"
+
+	apiKea "github.com/browningluke/opnsense-go/pkg/kea"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDhcpv4SubnetValidLifetimeSchemaToStruct(t *testing.T) {
+	model, err := convertDhcpv4SubnetStructToSchema(&apiKea.SubnetV4{})
+	require.NoError(t, err)
+	model.ValidLifetime = types.Int64Value(86400)
+
+	result, err := convertDhcpv4SubnetSchemaToStruct(model)
+	require.NoError(t, err)
+	require.Equal(t, "86400", result.ValidLifetime)
+}
+
+func TestDhcpv4SubnetValidLifetimeSchemaToStructUnset(t *testing.T) {
+	model, err := convertDhcpv4SubnetStructToSchema(&apiKea.SubnetV4{})
+	require.NoError(t, err)
+
+	result, err := convertDhcpv4SubnetSchemaToStruct(model)
+	require.NoError(t, err)
+	require.Empty(t, result.ValidLifetime)
+}
+
+func TestDhcpv4SubnetValidLifetimeStructToSchema(t *testing.T) {
+	model, err := convertDhcpv4SubnetStructToSchema(&apiKea.SubnetV4{ValidLifetime: "86400"})
+	require.NoError(t, err)
+	require.Equal(t, int64(86400), model.ValidLifetime.ValueInt64())
+
+	model, err = convertDhcpv4SubnetStructToSchema(&apiKea.SubnetV4{})
+	require.NoError(t, err)
+	require.True(t, model.ValidLifetime.IsNull())
+}


### PR DESCRIPTION
## Summary
- add optional `valid_lifetime` to the Kea DHCPv4 subnet resource
- expose the value from the corresponding data source
- validate non-negative values and preserve global inheritance when omitted
- add a v0-to-v1 state migration
- regenerate provider documentation

## Tests
- conversion unit tests cover configured and inherited lifetimes
- acceptance test covers create, read, import, update, and delete with 86400/43200-second values
- `OPNSENSE_URI=https://router.home make testacc PKG=kea TEST=TestAccKeaDhcpv4SubnetResource`
- `go test ./internal/service/kea ./internal/provider`
- `go build ./...`
- `go generate ./...`

## Dependency
Depends on browningluke/opnsense-go#97. This draft temporarily replaces `opnsense-go` with the tested fork commit; it should be changed to the upstream release containing that PR before merge.

The repository-wide `make test` also reaches existing OpenVPN acceptance-style tests and fails without `OPNSENSE_URI`; all impacted package tests pass.